### PR TITLE
AirPlay: Fix a streaming video/audio stopping after 1 minute

### DIFF
--- a/ConnectSDKTests/Services/Helpers/AirPlayServiceHTTPKeepAliveTests.m
+++ b/ConnectSDKTests/Services/Helpers/AirPlayServiceHTTPKeepAliveTests.m
@@ -1,0 +1,148 @@
+//
+//  AirPlayServiceHTTPKeepAliveTests.m
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 12/17/14.
+//  Copyright (c) 2014 LG Electronics. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#import "AirPlayServiceHTTPKeepAlive.h"
+#import "ServiceCommandDelegate.h"
+
+static const CGFloat kDefaultAsyncTestTimeout = 0.5f;
+static const CGFloat kDefaultKeepAliveInterval = 0.1f;
+
+
+/// Tests for the @c AirPlayServiceHTTPKeepAlive class.
+@interface AirPlayServiceHTTPKeepAliveTests : XCTestCase
+
+@property (nonatomic, strong) AirPlayServiceHTTPKeepAlive *keepAlive;
+@property (nonatomic, strong) id commandDelegateMock;
+
+@end
+
+@implementation AirPlayServiceHTTPKeepAliveTests
+
+#pragma mark - Setup
+
+- (void)setUp {
+    [super setUp];
+
+    self.commandDelegateMock = OCMProtocolMock(@protocol(ServiceCommandDelegate));
+    self.keepAlive = [[AirPlayServiceHTTPKeepAlive alloc] initWithInterval:kDefaultKeepAliveInterval
+                                                        andCommandDelegate:self.commandDelegateMock];
+    self.keepAlive.commandURL = [NSURL URLWithString:@"http://example.com/"];
+}
+
+- (void)tearDown {
+    self.keepAlive = nil;
+    self.commandDelegateMock = nil;
+
+    [super tearDown];
+}
+
+#pragma mark - Keep-Alive timer tests
+
+/// Tests that a newly created keep-alive object should not start automatically.
+- (void)testCreatedKeepAliveShouldNotBeStarted {
+    // Arrange
+    [[self.commandDelegateMock reject] sendCommand:OCMOCK_ANY
+                                       withPayload:OCMOCK_ANY
+                                             toURL:OCMOCK_ANY];
+    AirPlayServiceHTTPKeepAlive *keepAlive = [[AirPlayServiceHTTPKeepAlive alloc] initWithInterval:kDefaultKeepAliveInterval
+                                                                                andCommandDelegate:self.commandDelegateMock];
+    keepAlive.commandURL = [NSURL URLWithString:@"http://example.com/"];
+
+    // Act
+    [self runRunLoopForInterval:kDefaultAsyncTestTimeout];
+
+    // Assert
+    OCMVerifyAll(self.commandDelegateMock);
+}
+
+/// Tests that -startTimer makes the object send keep-alive commands.
+- (void)testStartTimerShouldSendRequest {
+    // Arrange
+    XCTestExpectation *sendKeepAliveExpectation = [self expectationWithDescription:@"Keep-alive is sent"];
+    OCMStub([self.commandDelegateMock sendCommand:[OCMArg isNotNil]
+                                      withPayload:OCMOCK_ANY
+                                            toURL:[OCMArg isNotNil]]).andDo(^(NSInvocation *_) {
+        [self.keepAlive stopTimer];
+        [sendKeepAliveExpectation fulfill];
+    });
+
+    // Act
+    [self.keepAlive startTimer];
+
+    // Assert
+    [self waitForExpectationsWithTimeout:kDefaultAsyncTestTimeout
+                                 handler:^(NSError *error) {
+                                     XCTAssertNil(error);
+                                     OCMVerifyAll(self.commandDelegateMock);
+                                 }];
+}
+
+/// Tests that -startTimer makes the object send keep-alive requests perodically.
+- (void)testStartTimerShouldSendRequests {
+    // Arrange
+    __block NSUInteger invocationCount = 0;
+    OCMStub([self.commandDelegateMock sendCommand:[OCMArg isNotNil]
+                                      withPayload:OCMOCK_ANY
+                                            toURL:[OCMArg isNotNil]]).andDo(^(NSInvocation *_) {
+        ++invocationCount;
+    });
+
+    // Act
+    [self.keepAlive startTimer];
+
+    // Assert
+    [self runRunLoopForInterval:kDefaultAsyncTestTimeout];
+    [self.keepAlive stopTimer];
+
+    const NSUInteger expectedInvocationCount = (NSUInteger)ceil(kDefaultAsyncTestTimeout / kDefaultKeepAliveInterval);
+    XCTAssertGreaterThanOrEqual(invocationCount,
+                                expectedInvocationCount - 1,
+                                @"The request wasn't sent the expected number of times");
+}
+
+/// Tests that -stopTimer after starting it stops the keep-alive requests.
+- (void)testStopTimerShouldStopSendingRequests {
+    // Arrange
+    id commandDelegateMock2 = OCMProtocolMock(@protocol(ServiceCommandDelegate));
+    [[commandDelegateMock2 reject] sendCommand:OCMOCK_ANY
+                                   withPayload:OCMOCK_ANY
+                                         toURL:OCMOCK_ANY];
+
+    OCMExpect([self.commandDelegateMock sendCommand:[OCMArg isNotNil]
+                                        withPayload:OCMOCK_ANY
+                                              toURL:[OCMArg isNotNil]]).andDo(^(NSInvocation *_) {
+        [self.keepAlive stopTimer];
+        // replace the delegate with a fresh mock
+        self.keepAlive.commandDelegate = commandDelegateMock2;
+    });
+
+    // Act
+    [self.keepAlive startTimer];
+
+    // Assert
+    [self runRunLoopForInterval:kDefaultAsyncTestTimeout];
+    OCMVerifyAll(self.commandDelegateMock);
+    OCMVerifyAll(commandDelegateMock2);
+}
+
+#pragma mark - Helpers
+
+- (void)runRunLoopForInterval:(CGFloat)interval {
+    NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:interval];
+    while ([timeoutDate timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:timeoutDate];
+    }
+}
+
+@end

--- a/Services/Helpers/AirPlayServiceHTTPKeepAlive.h
+++ b/Services/Helpers/AirPlayServiceHTTPKeepAlive.h
@@ -1,0 +1,42 @@
+//
+//  AirPlayServiceHTTPKeepAlive.h
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 12/17/14.
+//  Copyright (c) 2014 LG Electronics. All rights reserved.
+//
+
+@import Foundation;
+@import CoreGraphics;
+
+@protocol ServiceCommandDelegate;
+
+/// The class is responsible for maintaining an AirPlay connection alive by
+/// sending periodic requests.
+@interface AirPlayServiceHTTPKeepAlive : NSObject
+
+/// The interval between keep-alive requests, in seconds. 50 by default.
+@property (nonatomic, assign) CGFloat interval;
+
+/// An object that sends AirPlay commands.
+@property (nonatomic, weak) id<ServiceCommandDelegate> commandDelegate;
+
+/// The base URL for commands.
+@property (nonatomic, strong) NSURL *commandURL;
+
+
+/// Designated initializer, setting the interval and command delegate.
+- (instancetype)initWithInterval:(CGFloat)interval
+              andCommandDelegate:(id<ServiceCommandDelegate>)commandDelegate;
+
+/// Initializer that sets the command delegate.
+- (instancetype)initWithCommandDelegate:(id<ServiceCommandDelegate>)commandDelegate;
+
+/// Schedules sending keep-alive requests. The first one will be sent after the
+/// specified @c interval.
+- (void)startTimer;
+
+/// Stops sending keep-alive requests.
+- (void)stopTimer;
+
+@end

--- a/Services/Helpers/AirPlayServiceHTTPKeepAlive.m
+++ b/Services/Helpers/AirPlayServiceHTTPKeepAlive.m
@@ -1,0 +1,92 @@
+//
+//  AirPlayServiceHTTPKeepAlive.m
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 12/17/14.
+//  Copyright (c) 2014 LG Electronics. All rights reserved.
+//
+
+#import "AirPlayServiceHTTPKeepAlive.h"
+
+#import "ServiceCommand.h"
+
+@interface AirPlayServiceHTTPKeepAlive ()
+
+/// The keep-alive timer.
+@property (nonatomic, weak) NSTimer *timer;
+
+@end
+
+
+@implementation AirPlayServiceHTTPKeepAlive
+
+#pragma mark - Init
+
+- (instancetype)initWithInterval:(CGFloat)interval
+              andCommandDelegate:(id<ServiceCommandDelegate>)commandDelegate {
+    if (self = [super init]) {
+        _interval = interval;
+        _commandDelegate = commandDelegate;
+    }
+    return self;
+}
+
+- (instancetype)initWithCommandDelegate:(id<ServiceCommandDelegate>)commandDelegate {
+    // Apple TV 3 disconnects after 60 seconds of inactivity in an HTTP
+    // socket, so 50 seconds' keep-alive request should be enough
+    return [self initWithInterval:50
+               andCommandDelegate:commandDelegate];
+}
+
+- (instancetype)init {
+    return [self initWithCommandDelegate:nil];
+}
+
+- (void)dealloc {
+    [self stopTimer];
+}
+
+#pragma mark - Timer Management
+
+- (void)startTimer {
+    [self stopTimer];
+
+    DLog(@"Starting keep-alive timer");
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:self.interval
+                                                  target:self
+                                                selector:@selector(sendKeepAlive:)
+                                                userInfo:nil
+                                                 repeats:YES];
+}
+
+- (void)stopTimer {
+    if (self.timer) {
+        DLog(@"Stopping keep-alive timer");
+        [self.timer invalidate];
+        self.timer = nil;
+    }
+}
+
+#pragma mark - Private Methods
+
+- (void)sendKeepAlive:(NSTimer *)timer {
+    DLog(@"Sending keep-alive request");
+    NSParameterAssert(self.commandURL);
+
+    // the "/0" resource is unlikely to change to return something, as opposed
+    // to the "/" resource. a smaller response is better here
+    NSURL *keepAliveURL = [self.commandURL URLByAppendingPathComponent:@"0"];
+    ServiceCommand *keepAliveCommand = [ServiceCommand commandWithDelegate:self.commandDelegate
+                                                                    target:keepAliveURL
+                                                                   payload:nil];
+    keepAliveCommand.HTTPMethod = @"GET";
+    keepAliveCommand.callbackComplete = ^(id obj) {
+        DLog(@"%@: keep-alive success %@", NSStringFromClass(self.class), obj);
+    };
+    keepAliveCommand.callbackError = ^(NSError *error) {
+        DLog(@"%@: keep-alive error %@", NSStringFromClass(self.class), error);
+    };
+    [keepAliveCommand send];
+}
+
+@end


### PR DESCRIPTION
For some reason, Apple TV closes an inactive HTTP connection that is
used to play a video/audio and stops playing after 60 seconds. TCP
keep-alive packets do not help. This patch adds an explicit HTTP
keep-alive request that is sent via AirPlay every 50 seconds to maintain
the connection and keep the media playing.

Closes https://github.com/ConnectSDK/Connect-SDK-iOS/issues/106
