### PR TITLE
Fix a crash when discovering LG Speaker device

### DIFF
--- a/ConnectSDKTests/Discovery/Providers/SSDPDiscoveryProvider_FilteringTests.m
+++ b/ConnectSDKTests/Discovery/Providers/SSDPDiscoveryProvider_FilteringTests.m
@@ -119,6 +119,12 @@ static const NSUInteger kSSDPMulticastTCPPort = 1900;
         usingDiscoveryProviders:@[[DLNAService class]]];
 }
 
+- (void)testShouldFindLGSpeakerWithDLNAService {
+    [self checkShouldFindDevice:@"lg_speaker"
+       withExpectedFriendlyName:@"Music Flow H3"
+        usingDiscoveryProviders:@[[DLNAService class]]];
+}
+
 #pragma mark - DIAL Service Filtering Tests
 
 - (void)testShouldFindFireTVWithDIALService {

--- a/ConnectSDKTests/Discovery/Providers/sample_data/dlna/ssdp_device_description_lg_speaker.xml
+++ b/ConnectSDKTests/Discovery/Providers/sample_data/dlna/ssdp_device_description_lg_speaker.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0" xmlns:dlna="urn:schemas-dlna-org:device-1-0">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+  <device>
+    <dlna:X_DLNADOC>DMR-1.50</dlna:X_DLNADOC>
+    <deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>
+    <friendlyName>Music Flow H3</friendlyName>
+    <manufacturer>LG Electronics</manufacturer>
+    <manufacturerURL>http://www.lg.com</manufacturerURL>
+    <modelDescription>LG HTS</modelDescription>
+    <modelName>LG HTS</modelName>
+    <modelNumber>1.0</modelNumber>
+    <modelURL>http://www.lg.com</modelURL>
+    <UDN>uuid:140479c0-58f3-1cef-84bf-000ce7060000</UDN>
+    <serviceList>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
+        <serviceId>urn:upnp-org:serviceId:RenderingControl</serviceId>
+        <SCPDURL>/dmr_rcs.xml</SCPDURL>
+        <controlURL>control/RenderingControl</controlURL>
+        <eventSubURL>event/RenderingControl</eventSubURL>
+      </service>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:ConnectionManager:1</serviceType>
+        <serviceId>urn:upnp-org:serviceId:ConnectionManager</serviceId>
+        <SCPDURL>/dmr_cms.xml</SCPDURL>
+        <controlURL>control/ConnectionManager</controlURL>
+        <eventSubURL>event/ConnectionManager</eventSubURL>
+      </service>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>
+        <serviceId>urn:upnp-org:serviceId:AVTransport</serviceId>
+        <SCPDURL>/dmr_avts.xml</SCPDURL>
+        <controlURL>control/AVTransport</controlURL>
+        <eventSubURL>event/AVTransport</eventSubURL>
+      </service>
+    </serviceList>
+    <deviceList>
+      <device>
+        <deviceType>urn:lge-com:device:MultiroomSpk:1</deviceType>
+        <friendlyName>LG HTS</friendlyName>
+        <manufacturer>LG Electronics</manufacturer>
+        <manufacturerURL>http://www.lg.com</manufacturerURL>
+        <modelDescription>LG HTS</modelDescription>
+        <modelName>LG HTS</modelName>
+        <modelNumber>1.0</modelNumber>
+        <modelURL>http://www.lg.com</modelURL>
+        <UDN>uuid:00000000-0000-0000-0000-000000000000</UDN>
+      </device>
+    </deviceList>
+  </device>
+</root>

--- a/Discovery/Providers/SSDPDiscoveryProvider.m
+++ b/Discovery/Providers/SSDPDiscoveryProvider.m
@@ -544,7 +544,13 @@ containingRequiredServices:requiredServices];
     else if ([serviceList isKindOfClass:[NSDictionary class]])
         [list addObject:serviceList];
 
-    NSArray *devices = device[@"deviceList"][@"device"];
+    NSArray *devices = nil;
+    id devicesObject = device[@"deviceList"][@"device"];
+    if ([devicesObject isKindOfClass:[NSArray class]]) {
+        devices = devicesObject;
+    } else if ([devicesObject isKindOfClass:[NSDictionary class]]) {
+        devices = [NSArray arrayWithObject:devicesObject];
+    }
 
     if (devices)
     {


### PR DESCRIPTION
The device description XML lists only one `<device>` tag under the
`<deviceList>` section, which is parsed to return a dictionary, whereas
the code expected to get an array. This resulted in sending an
unrecognized selector `-[__NSDictionaryM enumerateObjectsUsingBlock:]`.
The patch explicitly checks for the returned type and adds the
dictionary to an array if necessary.