### PR TITLE
DLNA: Properly escape user data in XML requests

### DIFF
--- a/ConnectSDKTests/NSInvocation+ObjectGetter.h
+++ b/ConnectSDKTests/NSInvocation+ObjectGetter.h
@@ -1,0 +1,17 @@
+//
+//  NSInvocation+ObjectGetter.h
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 2/23/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSInvocation (ObjectGetter)
+
+/// Returns an object argument in the invocation at the given index.
+/// @warning The index is zero-based, as in a method definition!
+- (id)objectArgumentAtIndex:(NSInteger)idx;
+
+@end

--- a/ConnectSDKTests/NSInvocation+ObjectGetter.m
+++ b/ConnectSDKTests/NSInvocation+ObjectGetter.m
@@ -1,0 +1,21 @@
+//
+//  NSInvocation+ObjectGetter.m
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 2/23/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import "NSInvocation+ObjectGetter.h"
+
+@implementation NSInvocation (ObjectGetter)
+
+- (id)objectArgumentAtIndex:(NSInteger)idx {
+    __unsafe_unretained id tmp;
+    // the first two arguments are `self` and `_cmd`
+    [self getArgument:&tmp atIndex:(idx + 2)];
+    id object = tmp;
+    return object;
+}
+
+@end

--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -112,7 +112,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 
 /// Tests that @c -pauseWithSuccess:failure: creates a proper and valid Pause
 /// XML request.
-- (void)testPauseShouldCreateProperPlayXML {
+- (void)testPauseShouldCreateProperPauseXML {
     [self setupSendCommandTestWithName:@"Pause"
                            actionBlock:^{
                                [self.service pauseWithSuccess:^(id responseObject) {
@@ -125,7 +125,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 
 /// Tests that @c -stopWithSuccess:failure: creates a proper and valid Stop XML
 /// request.
-- (void)testStopShouldCreateProperPlayXML {
+- (void)testStopShouldCreateProperStopXML {
     [self setupSendCommandTestWithName:@"Stop"
                            actionBlock:^{
                                [self.service stopWithSuccess:^(id responseObject) {
@@ -134,6 +134,51 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
                                    XCTFail(@"fail? %@", error);
                                }];
                            } andVerificationBlock:nil];
+}
+
+/// Tests that @c -playNextWithSuccess:failure: creates a proper and valid Next
+/// XML request.
+- (void)testPlayNextShouldCreateProperNextXML {
+    [self setupSendCommandTestWithName:@"Next"
+                           actionBlock:^{
+                               [self.service playNextWithSuccess:^(id responseObject) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:nil];
+}
+
+/// Tests that @c -playPreviousWithSuccess:failure: creates a proper and valid
+/// Previous XML request.
+- (void)testPlayPreviousShouldCreateProperPreviousXML {
+    [self setupSendCommandTestWithName:@"Previous"
+                           actionBlock:^{
+                               [self.service playPreviousWithSuccess:^(id responseObject) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:nil];
+}
+
+/// Tests that @c -jumpToTrackWithIndex:success:failure: creates a proper and
+/// valid Seek XML request.
+- (void)testJumpToTrackShouldCreateProperSeekXML {
+    [self setupSendCommandTestWithName:@"Seek"
+                           actionBlock:^{
+                               [self.service jumpToTrackWithIndex:0
+                                                          success:^(id responseObject) {
+                                                              XCTFail(@"success?");
+                                                          } failure:^(NSError *error) {
+                                                              XCTFail(@"fail? %@", error);
+                                                          }];
+                           } andVerificationBlock:^(NSDictionary *request) {
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Target.text"],
+                                                     @"1", @"Track number is incorrect");
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Unit.text"],
+                                                     @"TRACK_NR", @"Unit is incorrect");
+                           }];
 }
 
 #pragma mark - Response Parsing Tests

--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -95,6 +95,47 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
                                                          andAlbumArtURL:nil];
 }
 
+/// Tests that @c -playWithSuccess:failure: creates a proper and valid Play XML
+/// request.
+- (void)testPlayShouldCreateProperPlayXML {
+    [self setupSendCommandTestWithName:@"Play"
+                           actionBlock:^{
+                               [self.service playWithSuccess:^(id responseObject) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:^(NSDictionary *request) {
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Speed.text"], @"1", @"Speed must equal 1");
+                           }];
+}
+
+/// Tests that @c -pauseWithSuccess:failure: creates a proper and valid Pause
+/// XML request.
+- (void)testPauseShouldCreateProperPlayXML {
+    [self setupSendCommandTestWithName:@"Pause"
+                           actionBlock:^{
+                               [self.service pauseWithSuccess:^(id responseObject) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:nil];
+}
+
+/// Tests that @c -stopWithSuccess:failure: creates a proper and valid Stop XML
+/// request.
+- (void)testStopShouldCreateProperPlayXML {
+    [self setupSendCommandTestWithName:@"Stop"
+                           actionBlock:^{
+                               [self.service stopWithSuccess:^(id responseObject) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:nil];
+}
+
 #pragma mark - Response Parsing Tests
 
 /// Tests that @c -getPositionWithSuccess:failure: parses the position time from

--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -45,95 +45,54 @@ static NSString *const kPlatformSonos = @"sonos";
 
 #pragma mark - Request Generation Tests
 
+static NSString *const kDefaultTitle = @"Hello, <World> &]]> \"others'\\ ура ξ中]]>…";
+static NSString *const kDefaultDescription = @"<Description> &\"'";
+static NSString *const kDefaultURL = @"http://example.com/media.ogg";
+static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
+
 /// Tests that @c -playMediaWithMediaInfo:shouldLoop:success:failure: creates a
 /// proper and valid SetAVTransportURI XML request.
 - (void)testPlayMediaShouldCreateProperSetAVTransportURIXML {
-    // Arrange
-    NSString *sampleURL = @"http://example.com/media.ogg";
-    NSString *sampleDescription = @"<Description> &\"'";
-    NSString *sampleTitle = @"Hello, <World> &]]> \"others'\\ ура ξ中]]>…";
-    NSString *sampleMimeType = @"audio/ogg";
-    NSString *sampleAlbumArtURL = @"http://example.com/media.png";
+    [self checkPlayMediaShouldCreateProperSetAVTransportURIXMLWithTitle:kDefaultTitle
+                                                            description:kDefaultDescription
+                                                                    url:kDefaultURL
+                                                         andAlbumArtURL:kDefaultAlbumArtURL];
+}
 
-    XCTestExpectation *commandIsSent = [self expectationWithDescription:@"SetAVTransportURI command is sent"];
+/// Tests that @c -playMediaWithMediaInfo:shouldLoop:success:failure: creates a
+/// proper and valid SetAVTransportURI XML request without title.
+- (void)testPlayMediaShouldCreateProperSetAVTransportURIXMLWithoutTitle {
+    [self checkPlayMediaShouldCreateProperSetAVTransportURIXMLWithTitle:nil
+                                                            description:kDefaultDescription
+                                                                    url:kDefaultURL
+                                                         andAlbumArtURL:kDefaultAlbumArtURL];
+}
 
-    [OCMExpect([self.serviceCommandDelegateMock sendCommand:OCMOCK_NOTNIL
-                                                withPayload:OCMOCK_NOTNIL
-                                                      toURL:OCMOCK_ANY]) andDo:^(NSInvocation *inv) {
-        NSDictionary *payload = [inv objectArgumentAtIndex:1];
-        NSString *xmlString = payload[kDataFieldName];
-        XCTAssertNotNil(xmlString, @"XML request not found");
+/// Tests that @c -playMediaWithMediaInfo:shouldLoop:success:failure: creates a
+/// proper and valid SetAVTransportURI XML request without description.
+- (void)testPlayMediaShouldCreateProperSetAVTransportURIXMLWithoutDescription {
+    [self checkPlayMediaShouldCreateProperSetAVTransportURIXMLWithTitle:kDefaultTitle
+                                                            description:nil
+                                                                    url:kDefaultURL
+                                                         andAlbumArtURL:kDefaultAlbumArtURL];
+}
 
-        NSError *error = nil;
-        NSDictionary *dict = [CTXMLReader dictionaryForXMLString:xmlString
-                                                           error:&error];
-        XCTAssertNil(error, @"XML parsing error");
-        XCTAssertNotNil(dict, @"Couldn't parse XML");
+/// Tests that @c -playMediaWithMediaInfo:shouldLoop:success:failure: creates a
+/// proper and valid SetAVTransportURI XML request without URL.
+- (void)testPlayMediaShouldCreateProperSetAVTransportURIXMLWithoutURL {
+    [self checkPlayMediaShouldCreateProperSetAVTransportURIXMLWithTitle:kDefaultTitle
+                                                            description:kDefaultDescription
+                                                                    url:nil
+                                                         andAlbumArtURL:kDefaultAlbumArtURL];
+}
 
-        NSDictionary *envelope = [dict objectForKeyEndingWithString:@":Envelope"];
-        XCTAssertNotNil(envelope, @"Envelope tag must be present");
-        NSDictionary *body = [envelope objectForKeyEndingWithString:@":Body"];
-        XCTAssertNotNil(body, @"Body tag must be present");
-        NSDictionary *request = [body objectForKeyEndingWithString:@":SetAVTransportURI"];
-        XCTAssertNotNil(request, @"SetAVTransportURI tag must be present");
-
-        XCTAssertNotNil(request[@"InstanceID"], @"InstanceID must be present");
-        XCTAssertEqualObjects([request valueForKeyPath:@"CurrentURI.text"], sampleURL, @"CurrentURI must match");
-
-        NSString *metadataString = [request valueForKeyPath:@"CurrentURIMetaData.text"];
-        XCTAssertNotNil(metadataString, @"CurrentURIMetaData must be present");
-
-        error = nil;
-        NSDictionary *metadata = [CTXMLReader dictionaryForXMLString:metadataString
-                                                               error:&error];
-        XCTAssertNil(error, @"Metadata XML parsing error");
-        XCTAssertNotNil(metadata, @"Couldn't parse metadata XML");
-
-        NSDictionary *didl = metadata[@"DIDL-Lite"];
-        XCTAssertNotNil(didl, @"DIDL-Lite tag must be present");
-        NSDictionary *item = didl[@"item"];
-        XCTAssertNotNil(item, @"item tag must be present");
-
-        NSString *title = [item objectForKeyEndingWithString:@":title"][@"text"];
-        XCTAssertEqualObjects(title, sampleTitle, @"Title must match");
-        NSString *description = [item objectForKeyEndingWithString:@":description"][@"text"];
-        XCTAssertEqualObjects(description, sampleDescription, @"Description must match");
-
-        NSDictionary *res = item[@"res"];
-        XCTAssertEqualObjects(res[@"text"], sampleURL, @"res URL must match");
-        XCTAssertNotEqual([res[@"protocolInfo"] rangeOfString:sampleMimeType].location, NSNotFound, @"mimeType must be in protocolInfo");
-
-        NSString *albumArtURI = [item objectForKeyEndingWithString:@":albumArtURI"][@"text"];
-        XCTAssertEqualObjects(albumArtURI, sampleAlbumArtURL, @"albumArtURI must match");
-
-        NSString *itemClass = [item objectForKeyEndingWithString:@":class"][@"text"];
-        XCTAssertEqualObjects(itemClass, @"object.item.audioItem", @"class must be audioItem");
-
-        [commandIsSent fulfill];
-    }];
-
-    MediaInfo *mediaInfo = [[MediaInfo alloc] initWithURL:[NSURL URLWithString:sampleURL]
-                                                 mimeType:sampleMimeType];
-    mediaInfo.title = sampleTitle;
-    mediaInfo.description = sampleDescription;
-    mediaInfo.images = @[[[ImageInfo alloc] initWithURL:[NSURL URLWithString:sampleAlbumArtURL]
-                                                   type:ImageTypeAlbumArt]];
-
-    // Act
-    [self.service playMediaWithMediaInfo:mediaInfo
-                              shouldLoop:NO
-                                 success:^(MediaLaunchObject *mediaLanchObject) {
-                                     XCTFail(@"success?");
-                                 } failure:^(NSError *error) {
-                                     XCTFail(@"fail? %@", error);
-                                 }];
-
-    // Assert
-    [self waitForExpectationsWithTimeout:kDefaultAsyncTestTimeout
-                                 handler:^(NSError *error) {
-                                     XCTAssertNil(error);
-                                     OCMVerifyAll(self.serviceCommandDelegateMock);
-                                 }];
+/// Tests that @c -playMediaWithMediaInfo:shouldLoop:success:failure: creates a
+/// proper and valid SetAVTransportURI XML request without album art URL.
+- (void)testPlayMediaShouldCreateProperSetAVTransportURIXMLWithoutAlbumArtURL {
+    [self checkPlayMediaShouldCreateProperSetAVTransportURIXMLWithTitle:kDefaultTitle
+                                                            description:kDefaultDescription
+                                                                    url:kDefaultURL
+                                                         andAlbumArtURL:nil];
 }
 
 #pragma mark - Response Parsing Tests
@@ -460,6 +419,95 @@ static NSString *const kPlatformSonos = @"sonos";
     dispatch_async(dispatch_get_main_queue(), ^{
         command.callbackComplete(dict);
     });
+}
+
+- (void)checkPlayMediaShouldCreateProperSetAVTransportURIXMLWithTitle:(NSString *)sampleTitle
+                                                          description:(NSString *)sampleDescription
+                                                                  url:(NSString *)sampleURL
+                                                       andAlbumArtURL:(NSString *)sampleAlbumArtURL {
+    // Arrange
+    NSString *sampleMimeType = @"audio/ogg";
+
+    XCTestExpectation *commandIsSent = [self expectationWithDescription:@"SetAVTransportURI command is sent"];
+
+    [OCMExpect([self.serviceCommandDelegateMock sendCommand:OCMOCK_NOTNIL
+                                                withPayload:OCMOCK_NOTNIL
+                                                      toURL:OCMOCK_ANY]) andDo:^(NSInvocation *inv) {
+        NSDictionary *payload = [inv objectArgumentAtIndex:1];
+        NSString *xmlString = payload[kDataFieldName];
+        XCTAssertNotNil(xmlString, @"XML request not found");
+
+        NSError *error = nil;
+        NSDictionary *dict = [CTXMLReader dictionaryForXMLString:xmlString
+                                                           error:&error];
+        XCTAssertNil(error, @"XML parsing error");
+        XCTAssertNotNil(dict, @"Couldn't parse XML");
+
+        NSDictionary *envelope = [dict objectForKeyEndingWithString:@":Envelope"];
+        XCTAssertNotNil(envelope, @"Envelope tag must be present");
+        NSDictionary *body = [envelope objectForKeyEndingWithString:@":Body"];
+        XCTAssertNotNil(body, @"Body tag must be present");
+        NSDictionary *request = [body objectForKeyEndingWithString:@":SetAVTransportURI"];
+        XCTAssertNotNil(request, @"SetAVTransportURI tag must be present");
+
+        XCTAssertNotNil(request[@"InstanceID"], @"InstanceID must be present");
+        XCTAssertEqualObjects([request valueForKeyPath:@"CurrentURI.text"], sampleURL, @"CurrentURI must match");
+
+        NSString *metadataString = [request valueForKeyPath:@"CurrentURIMetaData.text"];
+        XCTAssertNotNil(metadataString, @"CurrentURIMetaData must be present");
+
+        error = nil;
+        NSDictionary *metadata = [CTXMLReader dictionaryForXMLString:metadataString
+                                                               error:&error];
+        XCTAssertNil(error, @"Metadata XML parsing error");
+        XCTAssertNotNil(metadata, @"Couldn't parse metadata XML");
+
+        NSDictionary *didl = metadata[@"DIDL-Lite"];
+        XCTAssertNotNil(didl, @"DIDL-Lite tag must be present");
+        NSDictionary *item = didl[@"item"];
+        XCTAssertNotNil(item, @"item tag must be present");
+
+        NSString *title = [item objectForKeyEndingWithString:@":title"][@"text"];
+        XCTAssertEqualObjects(title, sampleTitle, @"Title must match");
+
+        NSString *description = [item objectForKeyEndingWithString:@":description"][@"text"];
+        XCTAssertEqualObjects(description, sampleDescription, @"Description must match");
+
+        NSDictionary *res = item[@"res"];
+        XCTAssertEqualObjects(res[@"text"], sampleURL, @"res URL must match");
+        XCTAssertNotEqual([res[@"protocolInfo"] rangeOfString:sampleMimeType].location, NSNotFound, @"mimeType must be in protocolInfo");
+
+        NSString *albumArtURI = [item objectForKeyEndingWithString:@":albumArtURI"][@"text"];
+        XCTAssertEqualObjects(albumArtURI, sampleAlbumArtURL, @"albumArtURI must match");
+
+        NSString *itemClass = [item objectForKeyEndingWithString:@":class"][@"text"];
+        XCTAssertEqualObjects(itemClass, @"object.item.audioItem", @"class must be audioItem");
+
+        [commandIsSent fulfill];
+    }];
+
+    MediaInfo *mediaInfo = [[MediaInfo alloc] initWithURL:[NSURL URLWithString:sampleURL]
+                                                 mimeType:sampleMimeType];
+    mediaInfo.title = sampleTitle;
+    mediaInfo.description = sampleDescription;
+    mediaInfo.images = @[[[ImageInfo alloc] initWithURL:[NSURL URLWithString:sampleAlbumArtURL]
+                                                   type:ImageTypeAlbumArt]];
+
+    // Act
+    [self.service playMediaWithMediaInfo:mediaInfo
+                              shouldLoop:NO
+                                 success:^(MediaLaunchObject *mediaLanchObject) {
+                                     XCTFail(@"success?");
+                                 } failure:^(NSError *error) {
+                                     XCTFail(@"fail? %@", error);
+                                 }];
+
+    // Assert
+    [self waitForExpectationsWithTimeout:kDefaultAsyncTestTimeout
+                                 handler:^(NSError *error) {
+                                     XCTAssertNil(error);
+                                     OCMVerifyAll(self.serviceCommandDelegateMock);
+                                 }];
 }
 
 @end

--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -20,6 +20,10 @@
 static NSString *const kPlatformXbox = @"xbox";
 static NSString *const kPlatformSonos = @"sonos";
 
+static NSString *const kAVTransportNamespace = @"urn:schemas-upnp-org:service:AVTransport:1";
+static NSString *const kRenderingControlNamespace = @"urn:schemas-upnp-org:service:RenderingControl:1";
+
+
 /// Tests for the @c DLNAService class.
 @interface DLNAServiceTests : XCTestCase
 
@@ -99,6 +103,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 /// request.
 - (void)testPlayShouldCreateProperPlayXML {
     [self setupSendCommandTestWithName:@"Play"
+                             namespace:kAVTransportNamespace
                            actionBlock:^{
                                [self.service playWithSuccess:^(id responseObject) {
                                    XCTFail(@"success?");
@@ -114,6 +119,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 /// XML request.
 - (void)testPauseShouldCreateProperPauseXML {
     [self setupSendCommandTestWithName:@"Pause"
+                             namespace:kAVTransportNamespace
                            actionBlock:^{
                                [self.service pauseWithSuccess:^(id responseObject) {
                                    XCTFail(@"success?");
@@ -127,6 +133,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 /// request.
 - (void)testStopShouldCreateProperStopXML {
     [self setupSendCommandTestWithName:@"Stop"
+                             namespace:kAVTransportNamespace
                            actionBlock:^{
                                [self.service stopWithSuccess:^(id responseObject) {
                                    XCTFail(@"success?");
@@ -136,10 +143,85 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
                            } andVerificationBlock:nil];
 }
 
+/// Tests that @c -getVolumeWithSuccess:failure: creates a proper and valid
+/// GetVolume XML request.
+- (void)testGetVolumeShouldCreateProperGetVolumeXML {
+    [self setupSendCommandTestWithName:@"GetVolume"
+                             namespace:kRenderingControlNamespace
+                           actionBlock:^{
+                               [self.service getVolumeWithSuccess:^(float volume) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:^(NSDictionary *request) {
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Channel.text"],
+                                                     @"Master", @"Channel must be Master");
+                           }];
+}
+
+/// Tests that @c -setVolume:success:failure: creates a proper and valid
+/// SetVolume XML request.
+- (void)testSetVolumeShouldCreateProperSetVolumeXML {
+    [self setupSendCommandTestWithName:@"SetVolume"
+                             namespace:kRenderingControlNamespace
+                           actionBlock:^{
+                               [self.service setVolume:0.99
+                                               success:^(id responseObject) {
+                                                   XCTFail(@"success?");
+                                               } failure:^(NSError *error) {
+                                                   XCTFail(@"fail? %@", error);
+                                               }];
+                           } andVerificationBlock:^(NSDictionary *request) {
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Channel.text"],
+                                                     @"Master", @"Channel must be Master");
+                               XCTAssertEqualObjects([request valueForKeyPath:@"DesiredVolume.text"],
+                                                     @"99", @"Volume is incorrect");
+                           }];
+}
+
+/// Tests that @c -getMuteWithSuccess:failure: creates a proper and valid
+/// GetMute XML request.
+- (void)testGetMuteShouldCreateProperGetMuteXML {
+    [self setupSendCommandTestWithName:@"GetMute"
+                             namespace:kRenderingControlNamespace
+                           actionBlock:^{
+                               [self.service getMuteWithSuccess:^(BOOL mute) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:^(NSDictionary *request) {
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Channel.text"],
+                                                     @"Master", @"Channel must be Master");
+                           }];
+}
+
+/// Tests that @c -setMute:success:failure: creates a proper and valid
+/// SetMute XML request.
+- (void)testSetMuteShouldCreateProperSetMuteXML {
+    [self setupSendCommandTestWithName:@"SetMute"
+                             namespace:kRenderingControlNamespace
+                           actionBlock:^{
+                               [self.service setMute:YES
+                                             success:^(id responseObject) {
+                                                 XCTFail(@"success?");
+                                             } failure:^(NSError *error) {
+                                                 XCTFail(@"fail? %@", error);
+                                             }];
+                           } andVerificationBlock:^(NSDictionary *request) {
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Channel.text"],
+                                                     @"Master", @"Channel must be Master");
+                               XCTAssertEqualObjects([request valueForKeyPath:@"DesiredMute.text"],
+                                                     @"1", @"DesiredMute is incorrect");
+                           }];
+}
+
 /// Tests that @c -playNextWithSuccess:failure: creates a proper and valid Next
 /// XML request.
 - (void)testPlayNextShouldCreateProperNextXML {
     [self setupSendCommandTestWithName:@"Next"
+                             namespace:kAVTransportNamespace
                            actionBlock:^{
                                [self.service playNextWithSuccess:^(id responseObject) {
                                    XCTFail(@"success?");
@@ -153,6 +235,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 /// Previous XML request.
 - (void)testPlayPreviousShouldCreateProperPreviousXML {
     [self setupSendCommandTestWithName:@"Previous"
+                             namespace:kAVTransportNamespace
                            actionBlock:^{
                                [self.service playPreviousWithSuccess:^(id responseObject) {
                                    XCTFail(@"success?");
@@ -166,6 +249,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 /// valid Seek XML request.
 - (void)testJumpToTrackShouldCreateProperSeekXML {
     [self setupSendCommandTestWithName:@"Seek"
+                             namespace:kAVTransportNamespace
                            actionBlock:^{
                                [self.service jumpToTrackWithIndex:0
                                                           success:^(id responseObject) {
@@ -508,8 +592,9 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 }
 
 - (void)setupSendCommandTestWithName:(NSString *)commandName
-                               actionBlock:(void (^)())actionBlock
-                      andVerificationBlock:(void (^)(NSDictionary *request))checkBlock {
+                           namespace:(NSString *)namespace
+                         actionBlock:(void (^)())actionBlock
+                andVerificationBlock:(void (^)(NSDictionary *request))checkBlock {
     // Arrange
     XCTestExpectation *commandIsSent = [self expectationWithDescription:
                                         [NSString stringWithFormat:@"%@ command is sent", commandName]];
@@ -529,6 +614,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
 
         NSDictionary *envelope = [dict objectForKeyEndingWithString:@":Envelope"];
         XCTAssertNotNil(envelope, @"Envelope tag must be present");
+        XCTAssertEqualObjects(envelope[@"xmlns:u"], namespace, @"Namespace is incorrect");
         NSDictionary *body = [envelope objectForKeyEndingWithString:@":Body"];
         XCTAssertNotNil(body, @"Body tag must be present");
         NSDictionary *request = [body objectForKeyEndingWithString:[@":" stringByAppendingString:commandName]];
@@ -562,6 +648,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
     NSString *sampleMimeType = @"audio/ogg";
 
     [self setupSendCommandTestWithName:@"SetAVTransportURI"
+                             namespace:kAVTransportNamespace
                            actionBlock:^{
                                MediaInfo *mediaInfo = [[MediaInfo alloc] initWithURL:[NSURL URLWithString:sampleURL]
                                                                             mimeType:sampleMimeType];

--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -50,8 +50,8 @@ static NSString *const kPlatformSonos = @"sonos";
 - (void)testPlayMediaShouldCreateProperSetAVTransportURIXML {
     // Arrange
     NSString *sampleURL = @"http://example.com/media.ogg";
-    NSString *sampleDescription = @"Description";
-    NSString *sampleTitle = @"hello";// @"Hello <World> & others…";
+    NSString *sampleDescription = @"<Description> &\"'";
+    NSString *sampleTitle = @"Hello, <World> &]]> \"others'\\ ура ξ中]]>…";
     NSString *sampleMimeType = @"audio/ogg";
     NSString *sampleAlbumArtURL = @"http://example.com/media.png";
 
@@ -67,7 +67,7 @@ static NSString *const kPlatformSonos = @"sonos";
         NSError *error = nil;
         NSDictionary *dict = [CTXMLReader dictionaryForXMLString:xmlString
                                                            error:&error];
-        XCTAssertNil(error, @"XML parsing error: %@", error);
+        XCTAssertNil(error, @"XML parsing error");
         XCTAssertNotNil(dict, @"Couldn't parse XML");
 
         NSDictionary *envelope = [dict objectForKeyEndingWithString:@":Envelope"];
@@ -86,7 +86,7 @@ static NSString *const kPlatformSonos = @"sonos";
         error = nil;
         NSDictionary *metadata = [CTXMLReader dictionaryForXMLString:metadataString
                                                                error:&error];
-        XCTAssertNil(error, @"Metadata XML parsing error: %@", error);
+        XCTAssertNil(error, @"Metadata XML parsing error");
         XCTAssertNotNil(metadata, @"Couldn't parse metadata XML");
 
         NSDictionary *didl = metadata[@"DIDL-Lite"];

--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -684,6 +684,7 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
         NSDictionary *envelope = [dict objectForKeyEndingWithString:@":Envelope"];
         XCTAssertNotNil(envelope, @"Envelope tag must be present");
         XCTAssertEqualObjects(envelope[@"xmlns:u"], namespace, @"Namespace is incorrect");
+        XCTAssertEqualObjects(envelope[@"s:encodingStyle"], @"http://schemas.xmlsoap.org/soap/encoding/");
         NSDictionary *body = [envelope objectForKeyEndingWithString:@":Body"];
         XCTAssertNotNil(body, @"Body tag must be present");
         NSDictionary *request = [body objectForKeyEndingWithString:[@":" stringByAppendingString:commandName]];

--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -143,6 +143,54 @@ static NSString *const kDefaultAlbumArtURL = @"http://example.com/media.png";
                            } andVerificationBlock:nil];
 }
 
+/// Tests that @c -seek:success:failure: creates a proper and valid Seek XML
+/// request.
+- (void)testSeekShouldCreateProperSeekXML {
+    [self setupSendCommandTestWithName:@"Seek"
+                             namespace:kAVTransportNamespace
+                           actionBlock:^{
+                               [self.service seek:(1 * 60 * 60) + (45 * 60) + 33
+                                          success:^(id responseObject) {
+                                              XCTFail(@"success?");
+                                          } failure:^(NSError *error) {
+                                              XCTFail(@"fail? %@", error);
+                                          }];
+                           } andVerificationBlock:^(NSDictionary *request) {
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Target.text"],
+                                                     @"01:45:33", @"Seek position is incorrect");
+                               XCTAssertEqualObjects([request valueForKeyPath:@"Unit.text"],
+                                                     @"REL_TIME", @"Unit is incorrect");
+                           }];
+}
+
+/// Tests that @c -getPlayStateWithSuccess:failure: creates a proper and valid
+/// GetTransportInfo XML request.
+- (void)testGetPlayStateShouldCreateProperGetTransportInfoXML {
+    [self setupSendCommandTestWithName:@"GetTransportInfo"
+                             namespace:kAVTransportNamespace
+                           actionBlock:^{
+                               [self.service getPlayStateWithSuccess:^(MediaControlPlayState playState) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:nil];
+}
+
+/// Tests that @c -getPositionWithSuccess:failure: creates a proper and valid
+/// GetPositionInfo XML request.
+- (void)testGetPositionInfoShouldCreateProperGetPositionInfoXML {
+    [self setupSendCommandTestWithName:@"GetPositionInfo"
+                             namespace:kAVTransportNamespace
+                           actionBlock:^{
+                               [self.service getPositionWithSuccess:^(NSTimeInterval position) {
+                                   XCTFail(@"success?");
+                               } failure:^(NSError *error) {
+                                   XCTFail(@"fail? %@", error);
+                               }];
+                           } andVerificationBlock:nil];
+}
+
 /// Tests that @c -getVolumeWithSuccess:failure: creates a proper and valid
 /// GetVolume XML request.
 - (void)testGetVolumeShouldCreateProperGetVolumeXML {

--- a/Frameworks/XMLReader/CTXMLReader.m
+++ b/Frameworks/XMLReader/CTXMLReader.m
@@ -31,21 +31,23 @@ NSString *const kCTXMLReaderAttributePrefix = @"@";
 
 + (NSDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError **)error
 {
-    CTXMLReader *reader = [[CTXMLReader alloc] initWithError:error];
-    NSDictionary *rootDictionary = [reader objectWithData:data options:0];
-    return rootDictionary;
+    return [[self class] dictionaryForXMLData:data options:0 error:error];
 }
 
 + (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError **)error
 {
     NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
-    return [CTXMLReader dictionaryForXMLData:data error:error];
+    return [CTXMLReader dictionaryForXMLData:data options:0 error:error];
 }
 
 + (NSDictionary *)dictionaryForXMLData:(NSData *)data options:(CTXMLReaderOptions)options error:(NSError **)error
 {
     CTXMLReader *reader = [[CTXMLReader alloc] initWithError:error];
     NSDictionary *rootDictionary = [reader objectWithData:data options:options];
+    if (!rootDictionary && error)
+    {
+        *error = reader.errorPointer;
+    }
     return rootDictionary;
 }
 
@@ -63,7 +65,7 @@ NSString *const kCTXMLReaderAttributePrefix = @"@";
     self = [super init];
     if (self)
     {
-        self.errorPointer = *error;
+        self.errorPointer = (error ? *error : nil);
     }
     return self;
 }

--- a/Frameworks/xswi/XMLWriter.h
+++ b/Frameworks/xswi/XMLWriter.h
@@ -1,0 +1,149 @@
+/***************************************************************************
+ *
+ * XMLWriter: An XML stream writer for iOS.
+ * This file is part of the XSWI library - http://code.google.com/p/xswi/
+ *
+ * Copyright (C) 2010 by Thomas Rørvik Skjølberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ****************************************************************************/
+
+#import <Foundation/Foundation.h>
+
+// xml stream writer
+@protocol XMLStreamWriter
+
+- (void) writeStartDocument;
+- (void) writeStartDocumentWithVersion:(NSString*)version;
+- (void) writeStartDocumentWithEncodingAndVersion:(NSString*)encoding version:(NSString*)version;
+
+- (void) writeStartElement:(NSString *)localName;
+
+- (void) writeEndElement; // automatic end element (mirrors previous start element at the same level)
+- (void) writeEndElement:(NSString *)localName;
+
+- (void) writeEmptyElement:(NSString *)localName;
+
+- (void) writeEndDocument; // write any remaining end elements
+
+- (void) writeAttribute:(NSString *)localName value:(NSString *)value;
+
+- (void) writeCharacters:(NSString*)text;
+- (void) writeComment:(NSString*)comment;
+- (void) writeProcessingInstruction:(NSString*)target data:(NSString*)data;
+- (void) writeCData:(NSString*)cdata;
+
+// return the written xml string buffer
+- (NSMutableString*) toString;
+// return the written xml as data, set to the encoding used in the writeStartDocumentWithEncodingAndVersion method (UTF-8 per default)
+- (NSData*) toData;
+
+// flush the buffers, if any
+- (void) flush;
+// close the writer and buffers, if any
+- (void) close;
+
+- (void) setPrettyPrinting:(NSString*)indentation withLineBreak:(NSString*)lineBreak;
+
+@end
+
+// xml stream writer with namespace support
+@protocol NSXMLStreamWriter <XMLStreamWriter>
+
+- (void) writeStartElementWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName;
+- (void) writeEndElementWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName;
+- (void) writeEmptyElementWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName;
+
+- (void) writeAttributeWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName value:(NSString *)value;
+
+// set a namespace and prefix
+- (void)setPrefix:(NSString*)prefix namespaceURI:(NSString *)namespaceURI;
+// write (and set) a namespace and prefix
+- (void) writeNamespace:(NSString*)prefix namespaceURI:(NSString *)namespaceURI;
+
+// set the default namespace (empty prefix)
+- (void)setDefaultNamespace:(NSString*)namespaceURI;
+// write (and set) the default namespace
+- (void) writeDefaultNamespace:(NSString*)namespaceURI;
+
+- (NSString*)getPrefix:(NSString*)namespaceURI;
+- (NSString*)getNamespaceURI:(NSString*)prefix;
+
+@end
+
+@interface XMLWriter : NSObject <NSXMLStreamWriter> {
+		
+	// the current output buffer
+	NSMutableString* writer;
+	
+	// the target encoding
+	NSString* encoding;
+	
+	// the number current levels
+	int level;
+	// is the element open, i.e. the end bracket has not been written yet
+	BOOL openElement;
+	// does the element contain characters, cdata, comments
+	BOOL emptyElement;
+	
+	// the element stack. one per element level
+	NSMutableArray* elementLocalNames;
+	NSMutableArray* elementNamespaceURIs;
+	
+	// the namespace array. zero or more namespace attributes can be defined per element level
+	NSMutableArray* namespaceURIs;
+	// the namespace count. one per element level
+	NSMutableArray* namespaceCounts;
+	// the namespaces which have been written to the stream
+	NSMutableArray* namespaceWritten;
+
+	// mapping of namespace URI to prefix and visa versa. Corresponds in size to the namespaceURIs array.
+	NSMutableDictionary* namespaceURIPrefixMap;
+	NSMutableDictionary* prefixNamespaceURIMap;
+
+	// tag indentation
+	NSString* indentation;
+	// line break
+	NSString* lineBreak;
+	
+	// if true, then write elements without children as <start /> instead of <start></start>
+	BOOL automaticEmptyElements;
+}
+
+@property (nonatomic, retain, readwrite) NSString* indentation;
+@property (nonatomic, retain, readwrite) NSString* lineBreak;
+@property (nonatomic, assign, readwrite) BOOL automaticEmptyElements;
+@property (nonatomic, readonly) int level;
+
+// helpful for formatting, special needs
+// write linebreak, if any
+- (void) writeLinebreak;
+// write indentation, if any
+- (void) writeIndentation;
+// write end of start element, so that the start tag is complete
+- (void) writeCloseStartElement;
+
+// write any outstanding namespace declaration attributes in a start element
+- (void) writeNamespaceAttributes;
+// write escaped text to the stream
+- (void) writeEscape:(NSString*)value;
+// wrote unescaped text to the stream
+- (void) write:(NSString*)value;
+
+@end

--- a/Frameworks/xswi/XMLWriter.m
+++ b/Frameworks/xswi/XMLWriter.m
@@ -1,0 +1,745 @@
+/***************************************************************************
+ *
+ * XMLWriter: An XML stream writer for iOS.
+ * This file is part of the XSWI library - http://code.google.com/p/xswi/
+ *
+ * Copyright (C) 2010 by Thomas Rørvik Skjølberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ****************************************************************************/
+
+#import "XMLWriter.h"
+
+#define NSBOOL(_X_) ((_X_) ? (id)kCFBooleanTrue : (id)kCFBooleanFalse)
+
+@interface XMLWriter (UtilityMethods)
+// methods for internal use only
+// pop the namespace stack, removing any namespaces which become out-of-scope
+- (void) popNamespaceStack;
+// push the namespace stack, denoting the namespaces whihch are in-scope
+- (void) pushNamespaceStack;
+
+// add namespace and local name to the top of the element stack
+- (void) pushElementStack:(NSString*)namespaceURI localName:(NSString*)localName;
+// remove the top member of the element stack
+- (void) popElementStack;
+
+// write close element, optionally as empty element
+- (void) writeCloseElement:(BOOL)empty;
+// write namespace attribute to stream
+- (void) writeNamespaceToStream:(NSString*)prefix namespaceURI:(NSString*)namespaceURI;
+// write a length of text to the stream with escaping
+- (void) writeEscapeCharacters:(const UniChar*)characters length:(int)length;
+@end
+
+
+static NSString *const EMPTY_STRING = @"";
+static NSString *const XML_NAMESPACE_URI = @"http://www.w3.org/XML/1998/namespace";
+static NSString *const XML_NAMESPACE_URI_PREFIX = @"xml";
+static NSString *const XMLNS_NAMESPACE_URI = @"http://www.w3.org/2000/xmlns/";
+static NSString *const XMLNS_NAMESPACE_URI_PREFIX = @"xmlns";
+static NSString *const XSI_NAMESPACE_URI = @"http://www.w3.org/2001/XMLSchema/";
+static NSString *const XSI_NAMESPACE_URI_PREFIX = @"xsi";
+
+@implementation XMLWriter
+
+@synthesize automaticEmptyElements, indentation, lineBreak, level;
+
+- (XMLWriter*) init {
+	self = [super init];
+	if (self != nil) {
+		// intialize variables
+		writer = [[NSMutableString alloc] init];
+		level = 0;
+		openElement = NO;
+		emptyElement = NO;
+        
+		elementLocalNames = [[NSMutableArray alloc]init];
+		elementNamespaceURIs = [[NSMutableArray alloc]init];
+        
+		namespaceURIs = [[NSMutableArray alloc]init];
+		namespaceCounts = [[NSMutableArray alloc]init];
+		namespaceWritten = [[NSMutableArray alloc]init];
+		
+		namespaceURIPrefixMap = [[NSMutableDictionary alloc] init];
+		prefixNamespaceURIMap = [[NSMutableDictionary alloc] init];
+		
+		// load default custom behaviour
+		automaticEmptyElements = YES;
+		
+		// setup default xml namespaces. assume both are previously known.
+		[namespaceCounts addObject:[NSNumber numberWithInt:2]];
+		[self setPrefix:XML_NAMESPACE_URI_PREFIX namespaceURI:XML_NAMESPACE_URI];
+		[self setPrefix:XMLNS_NAMESPACE_URI_PREFIX namespaceURI:XMLNS_NAMESPACE_URI];
+	}
+	return self;
+}
+
+- (void) pushNamespaceStack {
+	// step namespace count - add the current namespace count
+	NSNumber* previousCount = [namespaceCounts lastObject];
+	if([namespaceURIs count] == [previousCount intValue]) {
+		// the count is still the same
+		[namespaceCounts addObject:previousCount];
+	} else {
+		// the count has changed, save the it
+		NSNumber* count = [NSNumber numberWithInt:(int)[namespaceURIs count]];
+        
+		[namespaceCounts addObject:count];
+	}
+}
+
+- (void) writeNamespaceAttributes {
+	if(openElement) {
+		// write namespace attributes in the namespace stack
+		NSNumber* previousCount = [namespaceCounts lastObject];
+		for(int i = [previousCount intValue]; i < [namespaceURIs count]; i++) {
+			
+			// did we already write this namespace?
+			id written = [namespaceWritten objectAtIndex:i];
+			if(written == NSBOOL(NO)) {
+				// write namespace
+				NSString* namespaceURI = [namespaceURIs objectAtIndex:i];
+				NSString* prefix = [namespaceURIPrefixMap objectForKey:namespaceURI];
+				
+				[self writeNamespaceToStream:prefix namespaceURI:namespaceURI];
+				
+				[namespaceWritten replaceObjectAtIndex:i withObject:NSBOOL(YES)];
+			} else {
+				// already written namespace
+			}
+		}
+	} else {
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"No open start element" userInfo:NULL]);
+	}
+}
+
+- (void) popNamespaceStack {
+	// step namespaces one level down
+	if([namespaceCounts lastObject] != [namespaceCounts objectAtIndex:([namespaceCounts count] - 2)]) {
+		// remove namespaces which now are out of scope, i.e. between the current and the previus count
+		NSNumber* previousCount = [namespaceCounts lastObject];
+		NSNumber* currentCount = [namespaceCounts objectAtIndex:([namespaceCounts count] - 2)];
+		for(int i = [previousCount intValue] - 1; i >= [currentCount intValue]; i--) {
+			NSString* removedNamespaceURI = [namespaceURIs objectAtIndex:i];
+			NSString* removedPrefix = [namespaceURIPrefixMap objectForKey:removedNamespaceURI];
+			
+			[prefixNamespaceURIMap removeObjectForKey:removedPrefix];
+			[namespaceURIPrefixMap removeObjectForKey:removedNamespaceURI];
+			
+			[namespaceURIs removeLastObject];
+			
+			[namespaceWritten removeLastObject];
+		}
+	} else {
+		// not necessary to remove any namespaces
+	}
+	[namespaceCounts removeLastObject];
+}
+
+- (void)setPrefix:(NSString*)prefix namespaceURI:(NSString *)namespaceURI {
+	if(!namespaceURI) {
+		// raise exception
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"Namespace cannot be NULL" userInfo:NULL]);
+	}
+	if(!prefix) {
+		// raise exception
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"Prefix cannot be NULL" userInfo:NULL]);
+	}
+	if([namespaceURIPrefixMap objectForKey:namespaceURI]) {
+		// raise exception
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Name namespace %@ has already been set", namespaceURI] userInfo:NULL]);
+	}
+	if([prefixNamespaceURIMap objectForKey:prefix]) {
+		// raise exception
+		if([prefix length]) {
+			@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Prefix %@ has already been set", prefix] userInfo:NULL]);
+		} else {
+			@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"Default namespace has already been set" userInfo:NULL]);
+		}
+	}
+	
+	// increase the namespaces and add prefix mapping
+	[namespaceURIs addObject:namespaceURI];
+	[namespaceURIPrefixMap setObject:prefix forKey:namespaceURI];
+	[prefixNamespaceURIMap setObject:namespaceURI forKey:prefix];
+	
+	if(openElement) { // write the namespace now
+		[self writeNamespaceToStream:prefix namespaceURI:namespaceURI];
+		
+		[namespaceWritten addObject:NSBOOL(YES)];
+	} else {
+		// write the namespace as the next start element is closed
+		[namespaceWritten addObject:NSBOOL(NO)];
+	}
+}
+
+- (NSString*)getPrefix:(NSString*)namespaceURI {
+	return [namespaceURIPrefixMap objectForKey:namespaceURI];
+}
+
+- (void) pushElementStack:(NSString*)namespaceURI localName:(NSString*)localName {
+	// save for end elements
+	[elementLocalNames addObject:localName];
+	if(namespaceURI) {
+		[elementNamespaceURIs addObject:namespaceURI];
+	} else {
+		[elementNamespaceURIs addObject:EMPTY_STRING];
+	}
+}
+
+- (void) popElementStack {
+	// remove element traces
+	[elementNamespaceURIs removeLastObject];
+	[elementLocalNames removeLastObject];
+}
+
+- (void) writeStartDocument {
+	[self writeStartDocumentWithEncodingAndVersion:NULL version:NULL];
+}
+
+- (void) writeStartDocumentWithVersion:(NSString*)version {
+	[self writeStartDocumentWithEncodingAndVersion:NULL version:version];
+}
+
+- (void) writeStartDocumentWithEncodingAndVersion:(NSString*)aEncoding version:(NSString*)version {
+	if([writer length] != 0) {
+		// raise exception - Starting document which is not empty
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"Document has already been started" userInfo:NULL]);
+	} else {
+		[self write:@"<?xml version=\""];
+		if(version) {
+			[self write:version];
+		} else {
+			// default to 1.0
+			[self write:@"1.0"];
+		}
+		[self write:@"\""];
+		
+		if(aEncoding) {
+			[self write:@" encoding=\""];
+			[self write:aEncoding];
+			[self write:@"\""];
+			
+			encoding = aEncoding;
+		}
+		[self write:@" ?>"];
+		
+	}
+}
+
+- (void) writeEndDocument {
+	while (level > 0) {
+		[self writeEndElement];
+	}
+}
+
+- (void) writeStartElement:(NSString *)localName {
+	[self writeStartElementWithNamespace:NULL localName:localName];
+}
+
+- (void) writeCloseStartElement {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	} else {
+		// raise exception
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"No open start element" userInfo:NULL]);
+	}
+}
+
+- (void) writeCloseElement:(BOOL)empty {
+	[self writeNamespaceAttributes];
+	[self pushNamespaceStack];
+	
+	if(empty) {
+		[self write:@" />"];
+	} else {
+		[self write:@">"];
+	}
+	
+	openElement = NO;
+}
+
+- (void) writeEndElement:(NSString *)localName {
+	[self writeEndElementWithNamespace:NULL localName:localName];
+}
+
+- (void) writeEndElement {
+	if(openElement && automaticEmptyElements) {
+		// go for <START />
+		[self writeCloseElement:YES]; // write empty end element
+		
+		[self popNamespaceStack];
+		[self popElementStack];
+		
+		emptyElement = YES;
+		openElement = NO;
+		
+		level -= 1;
+	} else {
+		NSString* namespaceURI = [elementNamespaceURIs lastObject];
+		NSString* localName = [elementLocalNames lastObject];
+		
+		if(namespaceURI == EMPTY_STRING) {
+			[self writeEndElementWithNamespace:NULL localName:localName];
+		} else {
+			[self writeEndElementWithNamespace:namespaceURI localName:localName];
+		}
+	}
+}
+
+- (void) writeStartElementWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	}
+	
+	[self writeLinebreak];
+	[self writeIndentation];
+	
+	[self write:@"<"];
+	if(namespaceURI) {
+		NSString* prefix = [namespaceURIPrefixMap objectForKey:namespaceURI];
+		
+		if(!prefix) {
+			// raise exception
+			@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Unknown namespace URI %@", namespaceURI] userInfo:NULL]);
+		}
+		
+		if([prefix length]) {
+			[self write:prefix];
+			[self write:@":"];
+		}
+	}
+	[self write:localName];
+	
+	[self pushElementStack:namespaceURI localName:localName];
+	
+	openElement = YES;
+	emptyElement = YES;
+	level += 1;
+	
+}
+
+- (void) writeEndElementWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName {
+	if(level <= 0) {
+		// raise exception
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"Cannot write more end elements than start elements." userInfo:NULL]);
+	}
+	
+	level -= 1;
+	
+	if(openElement) {
+		// go for <START><END>
+		[self writeCloseElement:NO];
+	} else {
+		if(emptyElement) {
+			// go for linebreak + indentation + <END>
+			[self writeLinebreak];
+			[self writeIndentation];
+		} else {
+			// go for <START>characters<END>
+		}
+	}
+	
+	// write standard end element
+	[self write:@"</"];
+	
+	if(namespaceURI) {
+		NSString* prefix = [namespaceURIPrefixMap objectForKey:namespaceURI];
+		
+		if(!prefix) {
+			// raise exception
+			@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Unknown namespace URI %@", namespaceURI] userInfo:NULL]);
+		}
+		
+		if([prefix length]) {
+			[self write:prefix];
+			[self write:@":"];
+		}
+	}
+	
+	[self write:localName];
+	[self write:@">"];
+	
+	[self popNamespaceStack];
+	[self popElementStack];
+	
+	emptyElement = YES;
+	openElement = NO;
+}
+
+- (void) writeEmptyElement:(NSString *)localName {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	}
+	
+	[self writeLinebreak];
+	[self writeIndentation];
+	
+	[self write:@"<"];
+	[self write:localName];
+	[self write:@" />"];
+	
+	emptyElement = YES;
+	openElement = NO;
+}
+
+- (void) writeEmptyElementWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	}
+	
+	[self writeLinebreak];
+	[self writeIndentation];
+	
+	[self write:@"<"];
+	
+	if(namespaceURI) {
+		NSString* prefix = [namespaceURIPrefixMap objectForKey:namespaceURI];
+		
+		if(!prefix) {
+			// raise exception
+			@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Unknown namespace URI %@", namespaceURI] userInfo:NULL]);
+		}
+		
+		if([prefix length]) {
+			[self write:prefix];
+			[self write:@":"];
+		}
+	}
+	
+	[self write:localName];
+	[self write:@" />"];
+	
+	emptyElement = YES;
+	openElement = NO;
+}
+
+- (void) writeAttribute:(NSString *)localName value:(NSString *)value {
+	[self writeAttributeWithNamespace:NULL localName:localName value:value];
+}
+
+- (void) writeAttributeWithNamespace:(NSString *)namespaceURI localName:(NSString *)localName value:(NSString *)value {
+	if(openElement) {
+		[self write:@" "];
+		
+		if(namespaceURI) {
+			NSString* prefix = [namespaceURIPrefixMap objectForKey:namespaceURI];
+			if(!prefix) {
+				// raise exception
+				@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Unknown namespace URI %@", namespaceURI] userInfo:NULL]);
+			}
+			
+			if([prefix length]) {
+				[self write:prefix];
+				[self write:@":"];
+			}
+		}
+		[self write:localName];
+		[self write:@"=\""];
+		[self writeEscape:value];
+		[self write:@"\""];
+	} else {
+		// raise expection
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"No open start element" userInfo:NULL]);
+	}
+}
+
+- (void)setDefaultNamespace:(NSString*)namespaceURI {
+	[self setPrefix:EMPTY_STRING namespaceURI:namespaceURI];
+}
+
+- (void) writeNamespace:(NSString*)prefix namespaceURI:(NSString *)namespaceURI {
+	if(openElement) {
+		[self setPrefix:prefix namespaceURI:namespaceURI];
+	} else {
+		// raise exception
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"No open start element" userInfo:NULL]);
+	}
+}
+
+- (void) writeDefaultNamespace:(NSString*)namespaceURI {
+	[self writeNamespace:EMPTY_STRING namespaceURI:namespaceURI];
+}
+
+- (NSString*)getNamespaceURI:(NSString*)prefix {
+	return [prefixNamespaceURIMap objectForKey:prefix];
+}
+
+-(void) writeNamespaceToStream:(NSString*)prefix namespaceURI:(NSString*)namespaceURI {
+	if(openElement) { // write the namespace now
+		[self write:@" "];
+        
+		NSString* xmlnsPrefix = [self getPrefix:XMLNS_NAMESPACE_URI];
+		if(!xmlnsPrefix) {
+			// raise exception
+			@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Cannot declare namespace without namespace %@", XMLNS_NAMESPACE_URI] userInfo:NULL]);
+		}
+		
+		[self write:xmlnsPrefix]; // xmlns
+		if([prefix length]) {
+			// write xmlns:prefix="namespaceURI" attribute
+            
+			[self write:@":"]; // colon
+			[self write:prefix]; // prefix
+		} else {
+			// write xmlns="namespaceURI" attribute
+		}
+		[self write:@"=\""];
+		[self writeEscape:namespaceURI];
+		[self write:@"\""];
+	} else {
+		@throw([NSException exceptionWithName:@"XMLWriterException" reason:@"No open start element" userInfo:NULL]);
+	}
+}
+
+- (void) writeCharacters:(NSString*)text {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	}
+	
+	[self writeEscape:text];
+	
+	emptyElement = NO;
+}
+
+- (void) writeComment:(NSString*)comment {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	}
+	[self write:@"<!--"];
+	[self write:comment]; // no escape
+	[self write:@"-->"];
+	
+	emptyElement = NO;
+}
+
+- (void) writeProcessingInstruction:(NSString*)target data:(NSString*)data {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	}
+	[self write:@"<![CDATA["];
+	[self write:target]; // no escape
+	[self write:@" "];
+	[self write:data]; // no escape
+	[self write:@"]]>"];
+	
+	emptyElement = NO;
+}
+
+- (void) writeCData:(NSString*)cdata {
+	if(openElement) {
+		[self writeCloseElement:NO];
+	}
+	[self write:@"<![CDATA["];
+	[self write:cdata]; // no escape
+	[self write:@"]]>"];
+	
+	emptyElement = NO;
+}
+
+- (void) write:(NSString*)value {
+	[writer appendString:value];
+}
+
+- (void) writeEscape:(NSString*)value {
+	
+	const UniChar *characters = CFStringGetCharactersPtr((CFStringRef)value);
+	
+	if (characters) {
+		// main flow
+		[self writeEscapeCharacters:characters length:(int)[value length]];
+	} else {
+		// we need to read/copy the characters for some reason, from the docs of CFStringGetCharactersPtr:
+		// A pointer to a buffer of Unicode character or NULL if the internal storage of the CFString does not allow this to be returned efficiently.
+		// Whether or not this function returns a valid pointer or NULL depends on many factors, all of which depend on how the string was created and its properties. In addition, the function result might change between different releases and on different platforms. So do not count on receiving a non- NULL result from this function under any circumstances (except when the object is created with CFStringCreateMutableWithExternalCharactersNoCopy).
+		
+		// we dont need the whole data length at once
+		NSMutableData *data = [NSMutableData dataWithLength:256 * sizeof(UniChar)];
+		
+		if(!data) {
+			// raise exception - no more memory
+			@throw([NSException exceptionWithName:@"XMLWriterException" reason:[NSString stringWithFormat:@"Could not allocate data buffer of %i unicode characters", 256] userInfo:NULL]);
+		}
+		
+		int count = 0;
+		do {
+			int length;
+			if(count + 256 < [value length]) {
+				length = 256;
+			} else {
+				length = (int)[value length] - count;
+			}
+			
+			[value getCharacters:[data mutableBytes] range:NSMakeRange(count, length)];
+			
+			[self writeEscapeCharacters:[data bytes] length:length];
+			
+			count += length;
+		} while(count < [value length]);
+		
+		// buffers autorelease
+	}
+}
+
+- (void)writeEscapeCharacters:(const UniChar*)characters length:(int)length {
+	int rangeStart = 0;
+	int rangeLength = 0;
+	
+	for(int i = 0; i < length; i++) {
+		
+		UniChar c = characters[i];
+		if (c <= 0xd7ff)  {
+			if (c >= 0x20) {
+				switch (c) {
+					case 34: {
+						// write range if any
+						if(rangeLength) {
+							CFStringAppendCharacters((CFMutableStringRef)writer, characters + rangeStart, rangeLength);
+						}
+						[self write:@"&quot;"];
+						
+						break;
+					}
+						// quot
+					case 38: {
+						// write range if any
+						if(rangeLength) {
+							CFStringAppendCharacters((CFMutableStringRef)writer, characters + rangeStart, rangeLength);
+						}
+						[self write:@"&amp;"];
+						
+						break;
+					}
+						// amp;
+					case 60: {
+						// write range if any
+						if(rangeLength) {
+							CFStringAppendCharacters((CFMutableStringRef)writer, characters + rangeStart, rangeLength);
+						}
+						
+						[self write:@"&lt;"];
+						
+						break;
+					}
+						// lt;
+					case 62: {
+						// write range if any
+						if(rangeLength) {
+							CFStringAppendCharacters((CFMutableStringRef)writer, characters + rangeStart, rangeLength);
+						}
+						
+						[self write:@"&gt;"];
+						
+						break;
+					}
+						// gt;
+					default: {
+						// valid
+						rangeLength++;
+						
+						// note: we dont need to escape char 39 for &apos; because we use double quotes exclusively
+						
+						continue;
+					}
+				}
+				
+				// set range start to next
+				rangeLength = 0;
+				rangeStart = i + 1;
+				
+			} else {
+				if (c == '\n' || c == '\r' || c == '\t') {
+					// valid;
+					rangeLength++;
+					
+					continue;
+				} else {
+					// invalid, skip
+				}
+			}
+		} else if (c < 0xE000) {
+			// invalid, skip
+		} else if (c <= 0xFFFD) {
+			// valid
+			rangeLength++;
+			
+			continue;
+		} else {
+			// invalid, skip
+		}
+		
+		// write range if any
+		if(rangeLength) {
+			CFStringAppendCharacters((CFMutableStringRef)writer, characters + rangeStart, rangeLength);
+		}
+		
+		// set range start to next
+		rangeLength = 0;
+		rangeStart = i + 1;
+	}
+	
+	// write range if any
+	if(rangeLength) {
+		// main flow will probably write all characters here
+		CFStringAppendCharacters((CFMutableStringRef)writer, characters + rangeStart, rangeLength);
+	}
+}
+
+- (void)writeLinebreak {
+	if(lineBreak) {
+		[self write:lineBreak];
+	}
+}
+
+- (void)writeIndentation {
+	if(indentation) {
+		for (int i = 0; i < level; i++ ) {
+			[self write:indentation];
+		}
+	}
+}
+
+- (void) flush {
+	// do nothing
+}
+
+- (void) close {
+	// do nothing
+}
+
+- (NSMutableString*) toString {
+	return writer;
+}
+
+- (NSData*) toData {
+	if(encoding) {
+		return [writer dataUsingEncoding: CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef)encoding)) allowLossyConversion:NO];
+	} else {
+		return [writer dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:NO];
+	}
+}
+
+- (void) setPrettyPrinting:(NSString*)aIndentation withLineBreak:(NSString*)aLineBreak {
+    self.indentation = aIndentation;
+    self.lineBreak = aLineBreak;
+}
+
+
+@end

--- a/Helpers/NSString+Common.h
+++ b/Helpers/NSString+Common.h
@@ -1,0 +1,16 @@
+//
+//  NSString+Common.h
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 3/16/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (Common)
+
+/// Returns itself if not `nil`, or an empty string otherwise.
+- (NSString *)orEmpty;
+
+@end

--- a/Helpers/NSString+Common.m
+++ b/Helpers/NSString+Common.m
@@ -1,0 +1,18 @@
+//
+//  NSString+Common.m
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 3/16/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import "NSString+Common.h"
+
+@implementation NSString (Common)
+
+- (NSString *)orEmpty {
+    // TODO: replace DeviceService.ensureString()
+    return self ?: @"";
+}
+
+@end

--- a/Services/DLNAService.m
+++ b/Services/DLNAService.m
@@ -242,6 +242,7 @@ static const NSInteger kValueNotFound = -1;
     [writer setPrefix:@"u" namespaceURI:namespace];
 
     [writer writeElement:@"Envelope" withNamespace:kSOAPNamespace andContentsBlock:^(XMLWriter *writer) {
+        [writer writeAttribute:@"s:encodingStyle" value:@"http://schemas.xmlsoap.org/soap/encoding/"];
         [writer writeElement:@"Body" withNamespace:kSOAPNamespace andContentsBlock:^(XMLWriter *writer) {
             [writer writeElement:commandName withNamespace:namespace andContentsBlock:^(XMLWriter *writer) {
                 [writer writeElement:@"InstanceID" withContents:@"0"];

--- a/Services/DLNAService.m
+++ b/Services/DLNAService.m
@@ -507,22 +507,14 @@ static const NSInteger kValueNotFound = -1;
 
 - (void)playWithSuccess:(SuccessBlock)success failure:(FailureBlock)failure
 {
-    NSString *playXML = @"<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-            "<s:Envelope s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-            "<s:Body>"
-            "<u:Play xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">"
-            "<InstanceID>0</InstanceID>"
-            "<Speed>1</Speed>"
-            "</u:Play>"
-            "</s:Body>"
-            "</s:Envelope>";
+    NSString *playXML = [self commandXMLForCommandName:@"Play"
+                                        andWriterBlock:^(XMLWriter *writer) {
+                                            [writer writeElement:@"Speed" withContents:@"1"];
+                                        }];
+    NSDictionary *playPayload = @{kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Play\"",
+                                  kDataFieldName : playXML};
 
-    NSDictionary *playPayload = @{
-            kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Play\"",
-            kDataFieldName : playXML
-    };
-
-    ServiceCommand *playCommand = [[ServiceCommand alloc] initWithDelegate:self target:_avTransportControlURL payload:playPayload];
+    ServiceCommand *playCommand = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:playPayload];
     playCommand.callbackComplete = ^(NSDictionary *responseDic){
         if (success)
             success(nil);
@@ -533,21 +525,12 @@ static const NSInteger kValueNotFound = -1;
 
 - (void)pauseWithSuccess:(SuccessBlock)success failure:(FailureBlock)failure
 {
-    NSString *xml = @"<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-    "<s:Envelope s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-    "<s:Body>"
-    "<u:Pause xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">"
-    "<InstanceID>0</InstanceID>"
-    "</u:Pause>"
-    "</s:Body>"
-    "</s:Envelope>";
-    
-    NSDictionary *payload = @{
-                                  kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Pause\"",
-                                  kDataFieldName : xml
-                                  };
-    
-    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self target:_avTransportControlURL payload:payload];
+    NSString *pauseXML = [self commandXMLForCommandName:@"Pause"
+                                         andWriterBlock:nil];
+    NSDictionary *pausePayload = @{kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Pause\"",
+                                   kDataFieldName : pauseXML};
+
+    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:pausePayload];
     command.callbackComplete = ^(NSDictionary *responseDic){
         if (success)
             success(nil);
@@ -558,21 +541,12 @@ static const NSInteger kValueNotFound = -1;
 
 - (void)stopWithSuccess:(SuccessBlock)success failure:(FailureBlock)failure
 {
-    NSString *stopXML = @"<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-    "<s:Envelope s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-    "<s:Body>"
-    "<u:Stop xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">"
-    "<InstanceID>0</InstanceID>"
-    "</u:Stop>"
-    "</s:Body>"
-    "</s:Envelope>";
+    NSString *stopXML = [self commandXMLForCommandName:@"Stop"
+                                        andWriterBlock:nil];
+    NSDictionary *stopPayload = @{kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Stop\"",
+                                  kDataFieldName : stopXML};
     
-    NSDictionary *stopPayload = @{
-                                  kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Stop\"",
-                                  kDataFieldName : stopXML
-                                  };
-    
-    ServiceCommand *stopCommand = [[ServiceCommand alloc] initWithDelegate:self target:_avTransportControlURL payload:stopPayload];
+    ServiceCommand *stopCommand = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:stopPayload];
     stopCommand.callbackComplete = ^(NSDictionary *responseDic){
         if (success)
             success(nil);

--- a/Services/DLNAService.m
+++ b/Services/DLNAService.m
@@ -576,26 +576,16 @@ static const NSInteger kValueNotFound = -1;
 - (void)seek:(NSTimeInterval)position success:(SuccessBlock)success failure:(FailureBlock)failure
 {
     NSString *timeString = [self stringForTime:position];
+    NSString *seekXML = [self commandXMLForCommandName:@"Seek"
+                                      commandNamespace:kAVTransportNamespace
+                                        andWriterBlock:^(XMLWriter *writer) {
+                                            [writer writeElement:@"Unit" withContents:@"REL_TIME"];
+                                            [writer writeElement:@"Target" withContents:timeString];
+                                        }];
+    NSDictionary *seekPayload = @{kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Seek\"",
+                                  kDataFieldName : seekXML};
 
-    NSString *commandXML = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-            "<s:Envelope s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-            "<s:Body>"
-            "<u:Seek xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">"
-            "<InstanceID>0</InstanceID>"
-            "<Unit>REL_TIME</Unit>"
-            "<Target>%@</Target>"
-            "</u:Seek>"
-            "</s:Body>"
-            "</s:Envelope>",
-            timeString
-    ];
-
-    NSDictionary *commandPayload = @{
-            kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#Seek\"",
-            kDataFieldName : commandXML
-    };
-
-    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self target:_avTransportControlURL payload:commandPayload];
+    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:seekPayload];
     command.callbackComplete = success;
     command.callbackError = failure;
     [command send];
@@ -603,21 +593,13 @@ static const NSInteger kValueNotFound = -1;
 
 - (void)getPlayStateWithSuccess:(MediaPlayStateSuccessBlock)success failure:(FailureBlock)failure
 {
-    NSString *commandXML = @"<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-            "<s:Envelope s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-            "<s:Body>"
-            "<u:GetTransportInfo xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">"
-            "<InstanceID>0</InstanceID>"
-            "</u:GetTransportInfo>"
-            "</s:Body>"
-            "</s:Envelope>";
+    NSString *getPlayStateXML = [self commandXMLForCommandName:@"GetTransportInfo"
+                                              commandNamespace:kAVTransportNamespace
+                                                andWriterBlock:nil];
+    NSDictionary *getPlayStatePayload = @{kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#GetTransportInfo\"",
+                                          kDataFieldName : getPlayStateXML};
 
-    NSDictionary *commandPayload = @{
-            kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#GetTransportInfo\"",
-            kDataFieldName : commandXML
-    };
-
-    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:commandPayload];
+    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:getPlayStatePayload];
     command.callbackComplete = ^(NSDictionary *responseObject)
     {
         NSDictionary *response = [self responseDataFromResponse:responseObject
@@ -714,21 +696,13 @@ static const NSInteger kValueNotFound = -1;
 
 - (void) getPositionInfoWithSuccess:(SuccessBlock)success failure:(FailureBlock)failure
 {
-    NSString *commandXML = @"<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-            "<s:Envelope s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-            "<s:Body>"
-            "<u:GetPositionInfo xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">"
-            "<InstanceID>0</InstanceID>"
-            "</u:GetPositionInfo>"
-            "</s:Body>"
-            "</s:Envelope>";
+    NSString *getPositionInfoXML = [self commandXMLForCommandName:@"GetPositionInfo"
+                                                 commandNamespace:kAVTransportNamespace
+                                                   andWriterBlock:nil];
+    NSDictionary *getPositionInfoPayload = @{kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#GetPositionInfo\"",
+                                             kDataFieldName : getPositionInfoXML};
 
-    NSDictionary *commandPayload = @{
-            kActionFieldName : @"\"urn:schemas-upnp-org:service:AVTransport:1#GetPositionInfo\"",
-            kDataFieldName : commandXML
-    };
-
-    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:commandPayload];
+    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:getPositionInfoPayload];
     command.callbackComplete = success;
     command.callbackError = failure;
     [command send];

--- a/Services/DLNAService.m
+++ b/Services/DLNAService.m
@@ -27,7 +27,7 @@
 
 #import "NSDictionary+KeyPredicateSearch.h"
 
-#define kDataFieldName @"XMLData"
+NSString *const kDataFieldName = @"XMLData";
 #define kActionFieldName @"SOAPAction"
 #define kSubscriptionTimeoutSeconds 300
 
@@ -988,7 +988,7 @@ static const NSInteger kValueNotFound = -1;
                                    kDataFieldName : shareXML
                                    };
     
-    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self target:_avTransportControlURL payload:sharePayload];
+    ServiceCommand *command = [[ServiceCommand alloc] initWithDelegate:self.serviceCommandDelegate target:_avTransportControlURL payload:sharePayload];
     command.callbackComplete = ^(NSDictionary *responseDic)
     {
         [self playWithSuccess:^(id responseObject) {

--- a/Services/DLNAService_Private.h
+++ b/Services/DLNAService_Private.h
@@ -20,6 +20,8 @@
 
 #import "DLNAService.h"
 
+extern NSString *const kDataFieldName;
+
 @interface DLNAService ()
 
 @property (nonatomic, strong) id<ServiceCommandDelegate> serviceCommandDelegate;

--- a/Services/Helpers/XMLWriter+ConvenienceMethods.h
+++ b/Services/Helpers/XMLWriter+ConvenienceMethods.h
@@ -1,0 +1,28 @@
+//
+//  XMLWriter+ConvenienceMethods.h
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 3/16/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import "XMLWriter.h"
+
+@interface XMLWriter (ConvenienceMethods)
+
+- (void)writeElement:(NSString *)elementName withContents:(NSString *)contents;
+
+- (void)writeElement:(NSString *)elementName
+       withNamespace:(NSString *)namespace
+andContents:(NSString *)contents;
+
+- (void)writeElement:(NSString *)elementName
+   withContentsBlock:(void (^)(XMLWriter *writer))writerBlock;
+
+- (void)writeElement:(NSString *)elementName
+       withNamespace:(NSString *)namespace
+andContentsBlock:(void (^)(XMLWriter *writer))writerBlock;
+
+- (void)writeAttributes:(NSDictionary *)attributes;
+
+@end

--- a/Services/Helpers/XMLWriter+ConvenienceMethods.m
+++ b/Services/Helpers/XMLWriter+ConvenienceMethods.m
@@ -1,0 +1,54 @@
+//
+//  XMLWriter+ConvenienceMethods.m
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 3/16/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import "XMLWriter+ConvenienceMethods.h"
+
+@implementation XMLWriter (ConvenienceMethods)
+
+- (void)writeElement:(NSString *)elementName withContents:(NSString *)contents {
+    [self writeElement:elementName withNamespace:nil andContents:contents];
+}
+
+- (void)writeElement:(NSString *)elementName
+       withNamespace:(NSString *)namespace
+         andContents:(NSString *)contents {
+    [self writeElement:elementName
+         withNamespace:namespace
+      andContentsBlock:^(XMLWriter *xmlWriter) {
+          [xmlWriter writeCharacters:contents];
+      }];
+}
+
+- (void)writeElement:(NSString *)elementName
+   withContentsBlock:(void (^)(XMLWriter *))writerBlock {
+    [self writeElement:elementName
+         withNamespace:nil
+      andContentsBlock:writerBlock];
+}
+
+- (void)writeElement:(NSString *)elementName
+       withNamespace:(NSString *)namespace
+    andContentsBlock:(void (^)(XMLWriter *))writerBlock {
+    NSParameterAssert(writerBlock);
+
+    if (namespace) {
+        [self writeStartElementWithNamespace:namespace localName:elementName];
+    } else {
+        [self writeStartElement:elementName];
+    }
+    writerBlock(self);
+    [self writeEndElement];
+}
+
+- (void)writeAttributes:(NSDictionary *)attributes {
+    for (NSString *name in attributes) {
+        [self writeAttribute:name value:attributes[name]];
+    }
+}
+
+@end


### PR DESCRIPTION
Use the `XMLWriter` class from the [`xswi`](https://github.com/skjolber/xswi) library to properly build the XML requests and encode the input strings (which might contain illegal XML characters, such as `&`, `<`, `>`, and `"`). Add tests for all the changed request methods.

A fix for https://github.com/ConnectSDK/Connect-SDK-iOS/issues/138.