### PR TITLE
WebOSTVService: Resubscribe subscriptions after foregrounding

### DIFF
--- a/Services/Commands/ServiceSubscription.m
+++ b/Services/Commands/ServiceSubscription.m
@@ -114,4 +114,14 @@
     return clone;
 }
 
+#pragma mark - Debugging
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: callId=%ld; target=%@; "
+            @"payload=%@; #successCallbacks=%ld; #failureCallbacks=%ld>",
+            NSStringFromClass([self class]), (unsigned long)self.callId,
+            self.target, self.payload, (unsigned long)self.successCalls.count,
+            (unsigned long)self.failureCalls.count];
+}
+
 @end

--- a/Services/WebOSTVService.m
+++ b/Services/WebOSTVService.m
@@ -325,7 +325,7 @@
     }
 }
 
-#pragma - WebOSTVServiceSocketClientDelegate
+#pragma mark - WebOSTVServiceSocketClientDelegate
 
 - (void) socketWillRegister:(WebOSTVServiceSocketClient *)socket
 {


### PR DESCRIPTION
Save current subscriptions when the app is entering background, and
automagically resubscribe to them when entering foreground. It is
important that the `ServiceSubscription` objects are the same, because
the app is likely to retain them to be able to unsubscribe.

Unfortunately, functional tests for this change are missing, because
they would be pretty long and incomprehensible (the architecture is not
modularized enough).