### PR TITLE
DLNAService: stop the HTTP server on disconnect

### DIFF
--- a/ConnectSDKTests/OCMStubRecorder+XCTestExpectation.h
+++ b/ConnectSDKTests/OCMStubRecorder+XCTestExpectation.h
@@ -1,0 +1,28 @@
+//
+//  OCMStubRecorder+XCTestExpectation.h
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 4/24/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <OCMock/OCMock.h>
+
+@interface OCMStubRecorder (XCTestExpectation)
+
+/// Convenience method to fulfill an @c XCTestExpectation with a stub.
+- (id)andFulfillExpectation:(XCTestExpectation *)expectation;
+
+@end

--- a/ConnectSDKTests/OCMStubRecorder+XCTestExpectation.m
+++ b/ConnectSDKTests/OCMStubRecorder+XCTestExpectation.m
@@ -1,0 +1,31 @@
+//
+//  OCMStubRecorder+XCTestExpectation.m
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 4/24/15.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "OCMStubRecorder+XCTestExpectation.h"
+
+@implementation OCMStubRecorder (XCTestExpectation)
+
+- (id)andFulfillExpectation:(XCTestExpectation *)expectation {
+    return [self andDo:^(NSInvocation *invocation) {
+        [expectation fulfill];
+    }];
+}
+
+@end

--- a/Services/DLNAService.m
+++ b/Services/DLNAService.m
@@ -143,7 +143,7 @@ static const NSInteger kValueNotFound = -1;
         [self updateControlURLs];
 
         if (!_httpServer)
-            _httpServer = [DLNAHTTPServer new];
+            _httpServer = [self createDLNAHTTPServer];
     } else
     {
         _avTransportControlURL = nil;
@@ -196,7 +196,7 @@ static const NSInteger kValueNotFound = -1;
 //    NSString *targetPath = [NSString stringWithFormat:@"http://%@:%@/", self.serviceDescription.address, @(self.serviceDescription.port)];
 //    NSURL *targetURL = [NSURL URLWithString:targetPath];
 
-    _serviceReachability = [DeviceServiceReachability reachabilityWithTargetURL:_avTransportControlURL];
+    _serviceReachability = [self createDeviceServiceReachabilityWithTargetURL:_avTransportControlURL];
     _serviceReachability.delegate = self;
     [_serviceReachability start];
 
@@ -213,6 +213,8 @@ static const NSInteger kValueNotFound = -1;
 {
     self.connected = NO;
 
+    [self unsubscribeServices];
+    [_httpServer stop];
     [_serviceReachability stop];
 
     if (self.delegate && [self.delegate respondsToSelector:@selector(deviceService:disconnectedWithError:)])
@@ -1317,6 +1319,16 @@ static const NSInteger kValueNotFound = -1;
     command.callbackComplete = success;
     command.callbackError = failure;
     [command send];
+}
+
+#pragma mark - Private
+
+- (DLNAHTTPServer *)createDLNAHTTPServer {
+    return [DLNAHTTPServer new];
+}
+
+- (DeviceServiceReachability *)createDeviceServiceReachabilityWithTargetURL:(NSURL *)url {
+    return [DeviceServiceReachability reachabilityWithTargetURL:url];
 }
 
 @end

--- a/Services/DLNAService_Private.h
+++ b/Services/DLNAService_Private.h
@@ -22,6 +22,9 @@
 
 extern NSString *const kDataFieldName;
 
+@class DeviceServiceReachability;
+@class DLNAHTTPServer;
+
 @interface DLNAService ()
 
 @property (nonatomic, strong) id<ServiceCommandDelegate> serviceCommandDelegate;
@@ -30,5 +33,10 @@ extern NSString *const kDataFieldName;
 @property (nonatomic, strong) NSURL *avTransportEventURL;
 @property (nonatomic, strong) NSURL *renderingControlControlURL;
 @property (nonatomic, strong) NSURL *renderingControlEventURL;
+
+/// Creates a new @c DLNAHTTPServer instance.
+- (DLNAHTTPServer *)createDLNAHTTPServer;
+/// Creates a new @c DeviceServiceReachability instance with the given target URL.
+- (DeviceServiceReachability *)createDeviceServiceReachabilityWithTargetURL:(NSURL *)url;
 
 @end


### PR DESCRIPTION
And unsubscribe from all the subscribed services, because the server is shut down.

Fixes https://github.com/ConnectSDK/Connect-SDK-iOS/issues/118
