### PR TITLE
RokuService: fix media not playing on Roku build 6.2

### DIFF
--- a/ConnectSDKTests/Services/RokuServiceTests.m
+++ b/ConnectSDKTests/Services/RokuServiceTests.m
@@ -1,0 +1,66 @@
+//
+//  RokuServiceTests.m
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 2015-07-16.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import "RokuService_Private.h"
+
+#import "NSInvocation+ObjectGetter.h"
+
+@interface RokuServiceTests : XCTestCase
+
+@end
+
+@implementation RokuServiceTests
+
+- (void)testPlayVideoShouldSendNullEventURL {
+    NSURL *url = [NSURL URLWithString:@"http://example.com/"];
+    MediaInfo *videoInfo = [[MediaInfo alloc] initWithURL:url mimeType:@"video/mp4"];
+    [self checkPlayMediaShouldSendNullEventURLWithMediaInfo:videoInfo];
+}
+
+- (void)testPlayAudioShouldSendNullEventURL {
+    NSURL *url = [NSURL URLWithString:@"http://example.com/"];
+    MediaInfo *videoInfo = [[MediaInfo alloc] initWithURL:url mimeType:@"audio/ogg"];
+    [self checkPlayMediaShouldSendNullEventURLWithMediaInfo:videoInfo];
+}
+
+#pragma mark - Helpers
+
+- (void)checkPlayMediaShouldSendNullEventURLWithMediaInfo:(MediaInfo *)mediaInfo {
+    id serviceCommandDelegateMock = OCMProtocolMock(@protocol(ServiceCommandDelegate));
+    RokuService *service = [RokuService new];
+    service.serviceCommandDelegate = serviceCommandDelegateMock;
+
+    id serviceDescriptionMock = OCMClassMock([ServiceDescription class]);
+    [OCMStub([serviceDescriptionMock commandURL]) andReturn:[NSURL URLWithString:@"http://42"]];
+    service.serviceDescription = serviceDescriptionMock;
+
+    XCTestExpectation *commandSentExpectation = [self expectationWithDescription:@"command is sent"];
+
+    [OCMExpect([serviceCommandDelegateMock sendCommand:OCMOCK_NOTNIL
+                                           withPayload:OCMOCK_ANY
+                                                 toURL:OCMOCK_NOTNIL]) andDo:^(NSInvocation *inv) {
+        NSURL *url = [inv objectArgumentAtIndex:2];
+        NSURLComponents *components = [NSURLComponents componentsWithURL:url
+                                                 resolvingAgainstBaseURL:NO];
+        NSURLQueryItem *eventURLQueryItem = [[components.queryItems filteredArrayUsingPredicate:
+                                              [NSPredicate predicateWithFormat:@"%K == %@", @"name", @"h"]] firstObject];
+        XCTAssertEqualObjects(eventURLQueryItem.value, @"(null)",
+                              @"The event URL should be null, because we don't support them now");
+
+        [commandSentExpectation fulfill];
+    }];
+
+    [service playMediaWithMediaInfo:mediaInfo
+                         shouldLoop:NO
+                            success:nil
+                            failure:nil];
+
+    [self waitForExpectationsWithTimeout:kDefaultAsyncTestTimeout handler:nil];
+}
+
+@end

--- a/ConnectSDKTests/Services/RokuServiceTests.m
+++ b/ConnectSDKTests/Services/RokuServiceTests.m
@@ -5,6 +5,18 @@
 //  Created by Eugene Nikolskyi on 2015-07-16.
 //  Copyright (c) 2015 LG Electronics. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 
 #import "RokuService_Private.h"
 

--- a/ConnectSDKTests/Services/RokuServiceTests.m
+++ b/ConnectSDKTests/Services/RokuServiceTests.m
@@ -38,6 +38,16 @@
     }];
 }
 
+- (void)testDisplayImageShouldNotSendEventURL {
+    NSURL *url = [NSURL URLWithString:@"http://example.com/"];
+    MediaInfo *imageInfo = [[MediaInfo alloc] initWithURL:url mimeType:@"image/png"];
+    [self checkPlayMediaBlockShouldNotSendEventURL:^(RokuService *service) {
+        [service displayImageWithMediaInfo:imageInfo
+                                   success:nil
+                                   failure:nil];
+    }];
+}
+
 #pragma mark - Helpers
 
 - (void)checkPlayMediaBlockShouldNotSendEventURL:(void (^)(RokuService *service))testBlock {

--- a/Services/RokuService.m
+++ b/Services/RokuService.m
@@ -586,14 +586,14 @@ static NSMutableArray *registeredApps = nil;
     
     if (isVideo)
     {
-        applicationPath = [NSString stringWithFormat:@"15985?t=v&u=%@&k=(null)&h=(null)&videoName=%@&videoFormat=%@",
+        applicationPath = [NSString stringWithFormat:@"15985?t=v&u=%@&k=(null)&videoName=%@&videoFormat=%@",
                            [ConnectUtil urlEncode:mediaURL.absoluteString], // content path
                            title ? [ConnectUtil urlEncode:title] : @"(null)", // video name
                            ensureString(mediaType) // video format
                            ];
     } else
     {
-        applicationPath = [NSString stringWithFormat:@"15985?t=a&u=%@&k=(null)&h=(null)&songname=%@&artistname=%@&songformat=%@&albumarturl=%@",
+        applicationPath = [NSString stringWithFormat:@"15985?t=a&u=%@&k=(null)&songname=%@&artistname=%@&songformat=%@&albumarturl=%@",
                            [ConnectUtil urlEncode:mediaURL.absoluteString], // content path
                            title ? [ConnectUtil urlEncode:title] : @"(null)", // song name
                            description ? [ConnectUtil urlEncode:description] : @"(null)", // artist name

--- a/Services/RokuService.m
+++ b/Services/RokuService.m
@@ -18,7 +18,7 @@
 //  limitations under the License.
 //
 
-#import "RokuService.h"
+#import "RokuService_Private.h"
 #import "ConnectError.h"
 #import "CTXMLReader.h"
 #import "ConnectUtil.h"
@@ -176,6 +176,13 @@ static NSMutableArray *registeredApps = nil;
     }
 
     return _dialService;
+}
+
+#pragma mark - Getters & Setters
+
+/// Returns the set delegate property value or self.
+- (id<ServiceCommandDelegate>)serviceCommandDelegate {
+    return _serviceCommandDelegate ?: self;
 }
 
 #pragma mark - ServiceCommandDelegate
@@ -575,22 +582,19 @@ static NSMutableArray *registeredApps = nil;
     NSString *mediaType = [[mimeType componentsSeparatedByString:@"/"] lastObject];
     BOOL isVideo = [[mimeType substringToIndex:1] isEqualToString:@"v"];
     
-    NSString *host = [NSString stringWithFormat:@"%@:%@", self.serviceDescription.address, @(self.serviceDescription.port)];
     NSString *applicationPath;
     
     if (isVideo)
     {
-        applicationPath = [NSString stringWithFormat:@"15985?t=v&u=%@&k=(null)&h=%@&videoName=%@&videoFormat=%@",
+        applicationPath = [NSString stringWithFormat:@"15985?t=v&u=%@&k=(null)&h=(null)&videoName=%@&videoFormat=%@",
                            [ConnectUtil urlEncode:mediaURL.absoluteString], // content path
-                           [ConnectUtil urlEncode:host], // host
                            title ? [ConnectUtil urlEncode:title] : @"(null)", // video name
                            ensureString(mediaType) // video format
                            ];
     } else
     {
-        applicationPath = [NSString stringWithFormat:@"15985?t=a&u=%@&k=(null)&h=%@&songname=%@&artistname=%@&songformat=%@&albumarturl=%@",
+        applicationPath = [NSString stringWithFormat:@"15985?t=a&u=%@&k=(null)&h=(null)&songname=%@&artistname=%@&songformat=%@&albumarturl=%@",
                            [ConnectUtil urlEncode:mediaURL.absoluteString], // content path
-                           [ConnectUtil urlEncode:host], // host
                            title ? [ConnectUtil urlEncode:title] : @"(null)", // song name
                            description ? [ConnectUtil urlEncode:description] : @"(null)", // artist name
                            ensureString(mediaType), // audio format
@@ -606,7 +610,7 @@ static NSMutableArray *registeredApps = nil;
     
     NSURL *targetURL = [NSURL URLWithString:commandPath];
     
-    ServiceCommand *command = [ServiceCommand commandWithDelegate:self target:targetURL payload:nil];
+    ServiceCommand *command = [ServiceCommand commandWithDelegate:self.serviceCommandDelegate target:targetURL payload:nil];
     command.HTTPMethod = @"POST";
     command.callbackComplete = ^(id responseObject)
     {

--- a/Services/RokuService.m
+++ b/Services/RokuService.m
@@ -504,11 +504,8 @@ static NSMutableArray *registeredApps = nil;
         return;
     }
     
-    NSString *host = [NSString stringWithFormat:@"%@:%@", self.serviceDescription.address, @(self.serviceDescription.port)];
-    
-    NSString *applicationPath = [NSString stringWithFormat:@"15985?t=p&u=%@&h=%@&tr=crossfade",
-                                 [ConnectUtil urlEncode:imageURL.absoluteString], // content path
-                                 [ConnectUtil urlEncode:host] // host
+    NSString *applicationPath = [NSString stringWithFormat:@"15985?t=p&u=%@&tr=crossfade",
+                                 [ConnectUtil urlEncode:imageURL.absoluteString] // content path
                                  ];
     
     NSString *commandPath = [NSString pathWithComponents:@[
@@ -519,7 +516,7 @@ static NSMutableArray *registeredApps = nil;
     
     NSURL *targetURL = [NSURL URLWithString:commandPath];
     
-    ServiceCommand *command = [ServiceCommand commandWithDelegate:self target:targetURL payload:nil];
+    ServiceCommand *command = [ServiceCommand commandWithDelegate:self.serviceCommandDelegate target:targetURL payload:nil];
     command.HTTPMethod = @"POST";
     command.callbackComplete = ^(id responseObject)
     {

--- a/Services/RokuService_Private.h
+++ b/Services/RokuService_Private.h
@@ -1,0 +1,15 @@
+//
+//  RokuService_Private.h
+//  ConnectSDK
+//
+//  Created by Eugene Nikolskyi on 2015-07-16.
+//  Copyright (c) 2015 LG Electronics. All rights reserved.
+//
+
+#import "RokuService.h"
+
+@interface RokuService ()
+
+@property (nonatomic, strong) id<ServiceCommandDelegate> serviceCommandDelegate;
+
+@end


### PR DESCRIPTION
The fix is to send "(null)" as the events URL callback parameter ("h"),
because we don't support events now.

Fixes https://github.com/ConnectSDK/Connect-SDK-iOS/issues/166