### PR TITLE
DLNA: Ignore incorrect events in volume and mute subscriptions

### DIFF
--- a/ConnectSDKTests/Services/DLNAServiceTests.m
+++ b/ConnectSDKTests/Services/DLNAServiceTests.m
@@ -650,6 +650,54 @@ shouldContainSecTagWithDefaultFileTypeAndName:kSecCaptionInfoExTag];
                           @"The album art URL is incorrect");
 }
 
+#pragma mark - Subscription Tests
+
+- (void)testSubscribeVolumeShouldIgnoreMuteEvent {
+    // getVolume
+    OCMStub([self.serviceCommandDelegateMock sendCommand:OCMOCK_ANY
+                                             withPayload:OCMOCK_ANY
+                                                   toURL:OCMOCK_ANY]);
+
+    [[OCMExpect([self.serviceCommandDelegateMock sendSubscription:OCMOCK_ANY
+                                                             type:ServiceSubscriptionTypeSubscribe
+                                                          payload:OCMOCK_ANY
+                                                            toURL:OCMOCK_ANY
+                                                           withId:0]) ignoringNonObjectArgs] andDo:^(NSInvocation *invocation) {
+        ServiceSubscription *subscription = [invocation objectArgumentAtIndex:0];
+        SuccessBlock block = subscription.successCalls[0];
+        block(@{@"Event": @{@"InstanceID": @{@"Mute": @{@"channel": @"Master", @"val": @0}}}});
+    }];
+
+    [self.service subscribeVolumeWithSuccess:nil
+                                     failure:^(NSError *error) {
+                                         XCTFail(@"%@", error);
+                                     }];
+    OCMVerifyAll(self.serviceCommandDelegateMock);
+}
+
+- (void)testSubscribeMuteShouldIgnoreVolumeEvent {
+    // getMute
+    OCMStub([self.serviceCommandDelegateMock sendCommand:OCMOCK_ANY
+                                             withPayload:OCMOCK_ANY
+                                                   toURL:OCMOCK_ANY]);
+
+    [[OCMExpect([self.serviceCommandDelegateMock sendSubscription:OCMOCK_ANY
+                                                             type:ServiceSubscriptionTypeSubscribe
+                                                          payload:OCMOCK_ANY
+                                                            toURL:OCMOCK_ANY
+                                                           withId:0]) ignoringNonObjectArgs] andDo:^(NSInvocation *invocation) {
+        ServiceSubscription *subscription = [invocation objectArgumentAtIndex:0];
+        SuccessBlock block = subscription.successCalls[0];
+        block(@{@"Event": @{@"InstanceID": @{@"Volume": @{@"channel": @"Master", @"val": @0}}}});
+    }];
+
+    [self.service subscribeMuteWithSuccess:nil
+                                   failure:^(NSError *error) {
+                                       XCTFail(@"%@", error);
+                                   }];
+    OCMVerifyAll(self.serviceCommandDelegateMock);
+}
+
 #pragma mark - Disconnect Tests
 
 /// Tests that @c -disconnect shuts down the http server.

--- a/Services/DLNAService.m
+++ b/Services/DLNAService.m
@@ -1100,18 +1100,12 @@ static const NSInteger kValueNotFound = -1;
                                                      atChannel:@"Master"
                                                     inResponse:responseObject];
 
-        if (masterVolume == kValueNotFound)
-        {
-            if (failure)
-                failure([ConnectError generateErrorWithCode:ConnectStatusCodeError andDetails:@"Could not find volume in subscription response"]);
-        } else
-        {
-            if (success)
-                success((float) masterVolume / 100.0f);
+        if ((masterVolume != kValueNotFound) && success) {
+            success((float) masterVolume / 100.0f);
         }
     };
 
-    ServiceSubscription *subscription = [ServiceSubscription subscriptionWithDelegate:self target:_renderingControlEventURL payload:nil callId:-1];
+    ServiceSubscription *subscription = [ServiceSubscription subscriptionWithDelegate:self.serviceCommandDelegate target:_renderingControlEventURL payload:nil callId:-1];
     [subscription addSuccess:successBlock];
     [subscription addFailure:failure];
     [subscription subscribe];
@@ -1178,18 +1172,12 @@ static const NSInteger kValueNotFound = -1;
                                                    atChannel:@"Master"
                                                   inResponse:responseObject];
 
-        if (masterMute == kValueNotFound)
-        {
-            if (failure)
-                failure([ConnectError generateErrorWithCode:ConnectStatusCodeError andDetails:@"Could not find mute in subscription response"]);
-        } else
-        {
-            if (success)
-                success((BOOL) masterMute);
+        if ((masterMute != kValueNotFound) && success) {
+            success((BOOL) masterMute);
         }
     };
 
-    ServiceSubscription *subscription = [ServiceSubscription subscriptionWithDelegate:self target:_renderingControlEventURL payload:nil callId:-1];
+    ServiceSubscription *subscription = [ServiceSubscription subscriptionWithDelegate:self.serviceCommandDelegate target:_renderingControlEventURL payload:nil callId:-1];
     [subscription addSuccess:successBlock];
     [subscription addFailure:failure];
     [subscription subscribe];


### PR DESCRIPTION
Currently, both subscriptions use the same callback URL, so when either
event type is received, both callbacks are called. One of them called
the failure method, because it couldn't parse the event. This patch
makes them ignore incorrect data, similar to how other subscriptions
work.

Fixes https://github.com/ConnectSDK/Connect-SDK-iOS/issues/179