### PR TITLE
don't signal SIGPIPE on error when sending data

### DIFF
--- a/Helpers/SSDPSocketListener.m
+++ b/Helpers/SSDPSocketListener.m
@@ -166,17 +166,26 @@
 
 - (void)sendData:(NSData *)aData toAddress:(NSString *)anAddress andPort:(NSUInteger)aPort;
 {
-	if (0 == _socket)
+	if (0 == _socket) {
 		[self open];
+	}
 	
-	if (_socket <= 0)
+	if (_socket <= 0) {
 		[self raiseError];
+		return;
+	}
 	
 	struct sockaddr_in theSocketAddress;
 	
 	memset((char *) &theSocketAddress, 0, sizeof(theSocketAddress));
 	theSocketAddress.sin_family = AF_INET;
 	theSocketAddress.sin_port = htons(aPort);
+
+	int set = 1;
+	int success = setsockopt(_socket, SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(int));
+	if (success != 0) {
+		return;
+	}
 
 	inet_aton([anAddress UTF8String], &theSocketAddress.sin_addr);
 


### PR DESCRIPTION
Not quite ready to merge yet, need a few questions answered.

- Is this the best way to handle a possible `SIGPIPE`? The error is made non-fatal, but the error value can still be retrieved via `errno`.
- Should failing to initialize the socket exit the function early? The call to `sendto()` is guaranteed to fail if the socket isn't a valid value, so if that's the case we'll call `raiseError` twice.
- If the call to `setsockopt()` fails, should we `raiseError` or exit early?

Open to feedback. ✨