### PR TITLE
Prevents crash when SSDP device Discovery.

### DIFF
--- a/Discovery/Providers/SSDPDiscoveryProvider.m
+++ b/Discovery/Providers/SSDPDiscoveryProvider.m
@@ -95,16 +95,16 @@ static double searchAttemptsBeforeKill = 6.0;
 - (void) stopDiscovery
 {
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
-
+    
+    if (_refreshTimer)
+        [_refreshTimer invalidate];
+    
     if (_searchSocket)
         [_searchSocket close];
 
     if (_multicastSocket)
         [_multicastSocket close];
 
-    if (_refreshTimer)
-        [_refreshTimer invalidate];
-    
     _foundServices = [NSMutableDictionary new];
     _helloDevices = [NSMutableDictionary new];
     [_locationLoadQueue cancelAllOperations];

--- a/Helpers/SSDPSocketListener.m
+++ b/Helpers/SSDPSocketListener.m
@@ -139,14 +139,20 @@
 
 	_dispatchSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, theSocketDescriptor, 0, self.workQueue);
 	_socket = theSocketDescriptor;
-	dispatch_source_set_event_handler(_dispatchSource,
+	__weak __typeof__(self) weakSelf = self;
+	dispatch_source_set_event_handler(self->_dispatchSource,
 		^{
-			if (!self->_dispatchSource)
+			__typeof__(self) strongSelf = weakSelf;
+			if (strongSelf == nil) return;
+			if (!strongSelf->_socket || !strongSelf->_dispatchSource)
+			{
+				[strongSelf raiseError];
 				return;
+			}
 
 			struct sockaddr_in theIncomingAddr;
 			memset(&theIncomingAddr, 0, sizeof(theIncomingAddr));
-			size_t theDataSize = dispatch_source_get_data(self->_dispatchSource);
+			size_t theDataSize = dispatch_source_get_data(strongSelf->_dispatchSource);
 			char theBuffer[theDataSize + 1];
 			int theReceiveBytesCount = 0;
 			socklen_t theAddressSize = sizeof(theIncomingAddr);
@@ -163,15 +169,15 @@
 				length:strlen(theCAddrBuffer) encoding:NSUTF8StringEncoding];
 			NSData * theReceivedData = [NSData dataWithBytes:theBuffer length:theDataSize];
 
-			[self didReceiveData:theReceivedData fromAddress:thePath];
+			[strongSelf didReceiveData:theReceivedData fromAddress:thePath];
 		});
 
-	dispatch_source_set_cancel_handler(_dispatchSource,
+	dispatch_source_set_cancel_handler(self->_dispatchSource,
 		^{
 			close(self->_socket);
 		});
 	
-	dispatch_resume(_dispatchSource);
+	dispatch_resume(self->_dispatchSource);
 }
 
 


### PR DESCRIPTION
Crash has been observed during SSDP device discovery.
To fix possible crash, following fixes has been committed.

- Add null check for socketDescriptor.
- Apply weak and strong self references to prevent released function calls.