### PR TITLE
Fix crash issue in SSDPSocketListener.m

### DIFF
--- a/Helpers/SSDPSocketListener.m
+++ b/Helpers/SSDPSocketListener.m
@@ -154,20 +154,16 @@
 			memset(&theIncomingAddr, 0, sizeof(theIncomingAddr));
 			size_t theDataSize = dispatch_source_get_data(strongSelf->_dispatchSource);
 			char theBuffer[theDataSize + 1];
-			int theReceiveBytesCount = 0;
 			socklen_t theAddressSize = sizeof(theIncomingAddr);
-			while (theReceiveBytesCount < theDataSize)
-			{
-				theReceiveBytesCount += recvfrom(theSocketDescriptor, theBuffer,
-					sizeof(theBuffer), 0, (struct sockaddr*)&theIncomingAddr, &theAddressSize);
-			}
+			int theReceiveBytesCount = recvfrom(theSocketDescriptor, theBuffer,
+				sizeof(theBuffer), 0, (struct sockaddr*)&theIncomingAddr, &theAddressSize);
 			char theCAddrBuffer[SOCK_MAXADDRLEN];
 			memset(theCAddrBuffer, 0, SOCK_MAXADDRLEN);
 			inet_ntop(theIncomingAddr.sin_family, &theIncomingAddr.sin_addr, theCAddrBuffer, SOCK_MAXADDRLEN);
 
 			NSString *thePath = [[NSString alloc] initWithBytes:theCAddrBuffer
 				length:strlen(theCAddrBuffer) encoding:NSUTF8StringEncoding];
-			NSData * theReceivedData = [NSData dataWithBytes:theBuffer length:theDataSize];
+			NSData * theReceivedData = [NSData dataWithBytes:theBuffer length:theReceiveBytesCount];
 
 			[strongSelf didReceiveData:theReceivedData fromAddress:thePath];
 		});


### PR DESCRIPTION
This commit prevents the exception (EXC_BAD_ACCESS KERN_PROTECTION_FAILURE) by only copying the size of the received data.