### PR TITLE
Fix crash issue in DiscoveryManager.m

### DIFF
--- a/Discovery/DiscoveryManager.m
+++ b/Discovery/DiscoveryManager.m
@@ -265,7 +265,8 @@
         if ([interface caseInsensitiveCompare:@"en0"] != NSOrderedSame)
             return;
 
-        NSDictionary *info = (__bridge_transfer id) CNCopyCurrentNetworkInfo ((__bridge CFStringRef) interface);
+        CFDictionaryRef cfDict = CNCopyCurrentNetworkInfo((CFStringRef)interface);
+        NSDictionary *info = (NSDictionary *)CFBridgingRelease(cfDict);
 
         if (info && [info objectForKey:@"SSID"])
         {


### PR DESCRIPTION
This commit prevents the crash (BAD_ACCESS) when CNCopyCurrentNetworkInfo failed.