### PR TITLE
fix: lost devices remain in devicelist

### DIFF
--- a/Discovery/DiscoveryManager.m
+++ b/Discovery/DiscoveryManager.m
@@ -502,6 +502,7 @@
 /// Resumes all discovery providers and the SSID change timer.
 - (void)resumeDiscovery {
     // moved from -hAppDidBecomeActive:
+    [self purgeDeviceList];
     [self startSSIDTimer];
 
     if (_shouldResumeSearch)


### PR DESCRIPTION
If you resume an app from background, the deviceList can contain devices are disconnected (but were discovered before).
Because in background everything is paused and "didLoseDevice" (when a device is powered off) will never be called.
Therefore purgeDeviceList needs to be called upon resuming so deviceList (& DevicePicker) only show active devices.