### PR TITLE
Fixed ssid-change-timer double start

### DIFF
--- a/Discovery/DiscoveryManager.m
+++ b/Discovery/DiscoveryManager.m
@@ -244,6 +244,7 @@
 
 - (void) startSSIDTimer
 {
+    [_ssidTimer invalidate];
     _ssidTimer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(detectSSIDChange) userInfo:nil repeats:YES];
     [_ssidTimer fire];
 }

--- a/Services/Helpers/AirPlayServiceMirrored.m
+++ b/Services/Helpers/AirPlayServiceMirrored.m
@@ -515,7 +515,7 @@
 
 - (void)webViewDidFinishLoad:(WKWebView *)webView
 {
-    DLog(@"%@", webView.request.URL.absoluteString);
+    DLog(@"%@", webView.URL.absoluteString);
 
     if (self.launchSuccessBlock)
         self.launchSuccessBlock(nil);
@@ -526,7 +526,7 @@
 
 - (void)webViewDidStartLoad:(WKWebView *)webView
 {
-    DLog(@"%@", webView.request.URL.absoluteString);
+    DLog(@"%@", webView.URL.absoluteString);
 }
 
 @end


### PR DESCRIPTION
Hi. Right now ssid timer starts two times. So I think we need to invalidate it before scheduling.